### PR TITLE
Relaunch PC Recap 1.2 across GitHub and the web

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,14 +10,15 @@ body:
     id: version
     attributes:
       label: PC Recap version
-      placeholder: 1.0.1
+      placeholder: 1.2.0
     validations:
       required: true
   - type: input
-    id: windows
+    id: platform
     attributes:
-      label: Windows version
-      placeholder: Windows 11 24H2
+      label: Platform and version
+      description: Include CPU architecture and, on Linux, whether you use X11 or Wayland.
+      placeholder: Windows 11 x64, macOS 15 arm64, or Ubuntu 24.04 x64 X11
     validations:
       required: true
   - type: textarea

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot
+  categories:
+    - title: New memories
+      labels:
+        - enhancement
+        - feature
+    - title: Fixed
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other changes
+      labels:
+        - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to PC Recap are documented here.
 
+## [1.2.0] Beta - 2026-08-20
+
+### Added
+
+- Native foreground application collectors for macOS and Linux X11.
+- Tracking Health diagnostics for collector state, permissions, and the latest successful sample.
+- Separate active, idle, locked, suspended, and unavailable computer states.
+- Optional CPU, memory, battery, and power context with bounded raw retention and durable rollups.
+- Daily recovery backups, merge previews, canonical app identities, and long-archive performance improvements.
+- Cross-platform Windows, macOS Intel, macOS Apple Silicon, AppImage, and deb release packages with checksums.
+
+### Improved
+
+- Clearer local-clock times, chart tooltips, stat explanations, and recap observations.
+- Release packaging now verifies every artifact before a tag-driven GitHub Release is published.
+- Wayland reports its collector as unavailable instead of creating false activity.
+
+## [1.1.0] Beta - 2026-08-15
+
+### Added
+
+- Interactive Day Replay with proportional sessions and exact timeline details.
+- Recap Studio for historical, seasonal, and custom stories.
+- Memory Pins for local notes that stay out of stories and share cards unless included.
+- Exact ActivityWatch and ManicTime interval imports, with separated RescueTime and WakaTime context.
+- Historical Windows, Steam, and Epic clues that never convert evidence into invented usage time.
+- App rhythms, relationships, lifecycle facts, period comparisons, and evidence-based observations.
+
+### Improved
+
+- Search navigation, responsive layouts, interactive chart explanations, app identity normalization, and foreground collector resilience.
+
 ## [1.0.1] Beta - 2026-08-08
 
 ### Added
@@ -15,3 +47,5 @@ All notable changes to PC Recap are documented here.
 - Static download site and public repository documentation.
 
 [1.0.1]: https://github.com/TheAgencyMGE/pc-recap/releases/tag/v1.0.1
+[1.1.0]: https://github.com/TheAgencyMGE/pc-recap/releases/tag/v1.1.0
+[1.2.0]: https://github.com/TheAgencyMGE/pc-recap/releases/tag/v1.2.0

--- a/README.md
+++ b/README.md
@@ -1,69 +1,88 @@
-# PC Recap
+<p align="center">
+  <img src="website/favicon.svg" width="88" height="88" alt="PC Recap logo" />
+</p>
 
-PC Recap turns real computer activity into a visual history of your digital life: daily snapshots, weekly and monthly recaps, a cinematic Yearly Recap, long-term eras, records, and an archive you can carry between computers.
+<h1 align="center">PC Recap</h1>
 
-[Website](https://pcrecap.online/) · [Download](https://github.com/TheAgencyMGE/pc-recap/releases/latest) · [GPL-3.0 license](LICENSE)
+<p align="center"><strong>Your computer life, played back.</strong></p>
 
-![PC Recap cover shelf](website/og.png)
+<p align="center">
+  A free, open-source visual time capsule for the apps, eras, late nights,<br />
+  records, and strange little patterns that made your computer history yours.
+</p>
 
-> [!IMPORTANT]
-> **PC Recap 1.2.0 is a cross-platform beta.** Windows, macOS, and Linux packages are currently unsigned; macOS builds are not notarized. Updates are installed manually from [GitHub Releases](https://github.com/TheAgencyMGE/pc-recap/releases), and beta users may encounter bugs. [Report a bug](https://github.com/TheAgencyMGE/pc-recap/issues/new?template=bug_report.yml) or [suggest an improvement](https://github.com/TheAgencyMGE/pc-recap/issues/new?template=feature_request.yml).
+<p align="center">
+  <a href="https://pcrecap.online/">Website</a> ·
+  <a href="https://github.com/TheAgencyMGE/pc-recap/releases/latest">Download</a> ·
+  <a href="docs/INSTALL.md">Install guide</a> ·
+  <a href="https://github.com/TheAgencyMGE/pc-recap/issues">Issues</a>
+</p>
 
-## What it does
+<p align="center">
+  <a href="https://github.com/TheAgencyMGE/pc-recap/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/TheAgencyMGE/pc-recap?display_name=tag&style=flat-square&color=3957ff" /></a>
+  <a href="https://github.com/TheAgencyMGE/pc-recap/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/TheAgencyMGE/pc-recap/actions/workflows/ci.yml/badge.svg?branch=main" /></a>
+  <a href="LICENSE"><img alt="GPL-3.0 license" src="https://img.shields.io/badge/license-GPL--3.0--only-c7f000?style=flat-square&labelColor=171717" /></a>
+  <img alt="Windows, macOS, and Linux" src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-ff4f32?style=flat-square&labelColor=171717" />
+</p>
 
-- Records foreground application usage on Windows, macOS, and Linux X11; Wayland reports an unavailable collector instead of fabricating activity.
-- Keeps active, idle, locked, suspended, and unavailable time separate so idle never ranks as an app.
-- Optionally records lightweight CPU, memory, battery, and power-state context with bounded raw retention and durable rollups.
-- Builds Today, Week, Month, Year, All-Time, Decade, and On This Day recaps.
-- Finds deterministic observations, app pairings, streaks, records, and usage eras without AI services.
-- Replays individual days on a proportional, interactive timeline with exact local-clock labels.
-- Builds historical, seasonal, and custom stories in Recap Studio.
-- Imports exact ActivityWatch and ManicTime intervals, plus clearly separated RescueTime and WakaTime context.
-- Recovers local Windows application clues plus Steam and Epic launcher evidence without converting clues into usage time or inventing playtime.
-- Adds local Memory Pins that stay out of stories and share cards unless explicitly included.
-- Keeps history in local SQLite storage with per-app exclusions.
-- Exports and merges versioned `.pcr` backups across computers.
-- Runs from the system tray and continues collecting when the window is closed.
-- Uses native application icons and exports shareable Recap cards locally.
+![PC Recap cover shelf with Today, Week, Year, Timeline, and On This Day recaps](website/og.png)
 
-PC Recap never creates demo activity or placeholder statistics. A new archive is empty until real sessions are collected or imported.
+## A time capsule, not a timesheet
 
-## Download
+Most activity trackers focus on productivity. PC Recap is built for remembering. It records real foreground app activity, keeps it in a local SQLite archive, and turns that history into visual daily, weekly, monthly, yearly, and long-term recaps.
 
-PC Recap 1.2 packages are prepared for Windows x64 (NSIS), macOS Intel and Apple Silicon (DMG), and Linux x64 (AppImage and deb). Download the package for your computer from [GitHub Releases](https://github.com/TheAgencyMGE/pc-recap/releases/latest).
+There are no productivity grades and no invented demo activity. A new archive begins empty, then grows from sessions PC Recap actually observes or history you explicitly import.
 
-Linux foreground tracking currently requires an X11 session. Wayland does not expose a reliable universal foreground-window API, so PC Recap shows the collector as unavailable there.
+## What PC Recap remembers
 
-Windows may show SmartScreen because the installer is not Authenticode-signed. macOS may show Gatekeeper because the beta DMGs are not yet signed or notarized. PC Recap does not update automatically yet.
+- **Your recaps:** Today, Week, Month, Year, All-Time, Decade, On This Day, and a zoomable historical timeline.
+- **Your patterns:** favorite apps, categories, pairings, streaks, records, comparisons, late-night habits, and automatically detected eras.
+- **Your days:** first and last activity, longest sessions, honest active and idle time, and an interactive Day Replay.
+- **Your computer's pulse:** optional CPU, memory, battery, and power context alongside the moments that pushed your system.
+- **Your old history:** exact intervals from supported trackers, plus clearly labeled historical clues that never pretend to be measured usage.
+- **Your own stories:** custom Recap Studio stories, local Memory Pins, and shareable recap cards.
+- **Your archive:** versioned `.pcr` backups, merge previews, daily recovery backups, and storage designed for years of history.
 
-## Privacy
+Observations are generated by deterministic rules. PC Recap does not call an AI service or send activity data to one.
 
-- No account, telemetry, advertising identifier, cloud sync, or external AI API.
-- No keystrokes, screenshots, clipboard contents, or file contents.
-- No browser-history or URL scanning. Recovered clues never count as usage duration.
-- Window titles are off by default.
-- Performance history stores supported system utilization samples locally and can be disabled independently.
-- Performance sampling and database growth have a reproducible local benchmark in [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md).
-- Tracking can be paused immediately and individual executables can be excluded.
-- All history can be exported or erased from the app.
-- The marketing website uses Plausible for aggregate page and download analytics; the desktop app remains telemetry-free and never sends activity history.
+## Download PC Recap 1.2
 
-See [SECURITY.md](SECURITY.md) for vulnerability reporting.
+| System | Package | Notes |
+| --- | --- | --- |
+| Windows 10/11 x64 | [Setup.exe](https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-Setup.exe) | Foreground tracking, tray mode, and optional startup launch |
+| macOS 12+ Apple Silicon | [DMG](https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-mac-arm64.dmg) | For M1, M2, M3, M4, and newer Apple silicon Macs |
+| macOS 12+ Intel | [DMG](https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-mac-x64.dmg) | For Intel-based Macs |
+| Linux x64 | [AppImage](https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-linux-x64.AppImage) · [deb](https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-linux-x64.deb) | Foreground tracking currently requires X11 and `xprop` |
 
-Third-party font notices are listed in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+These beta packages are unsigned, and macOS builds are not notarized. Windows SmartScreen or macOS Gatekeeper may therefore show a warning. Read the [install guide](docs/INSTALL.md) for safe, platform-specific steps and checksum verification.
 
-## Development
+Wayland does not expose a reliable universal foreground-window API. PC Recap opens on Wayland but reports its foreground collector as unavailable instead of inventing activity.
 
-Requirements: Node.js 22 or newer and npm. Build distributables on their target operating system.
+## Built to be inspectable
+
+- Activity and optional performance history stay on your computer.
+- No account, desktop telemetry, cloud sync, advertising identifier, or external AI API.
+- No keystrokes, screenshots, clipboard contents, file contents, browser-history scanning, or URL collection.
+- Window-title collection is optional and off by default.
+- Per-app exclusions, independent performance controls, immediate pause, export, and erase controls are built in.
+- The renderer is sandboxed and context-isolated. Node integration is disabled and IPC is explicitly allowlisted.
+
+The product website uses Plausible for aggregate page and download analytics. The desktop app itself remains telemetry-free and never sends computer activity.
+
+Read the [security model](SECURITY.md), [performance notes](docs/PERFORMANCE.md), and [third-party notices](THIRD_PARTY_NOTICES.md).
+
+## Run it locally
+
+PC Recap requires Node.js 22 or newer and npm.
 
 ```powershell
 npm ci
 npm run dev
 ```
 
-`npm run dev` builds the Electron main process, starts the renderer development server, and opens the actual desktop application.
+`npm run dev` launches the actual Electron desktop app. It also runs the local React renderer and watches the Electron main and preload processes.
 
-Quality checks:
+Run the quality suite:
 
 ```powershell
 npm run test:run
@@ -71,9 +90,11 @@ npm run typecheck
 npm run smoke:activity
 npm run build
 npm run smoke:visual
+npm run promotion:test
+npm run website:validate
 ```
 
-Create platform packages:
+Build packages on their target operating systems:
 
 ```text
 npm run package:win
@@ -81,46 +102,38 @@ npm run package:mac
 npm run package:linux
 ```
 
-Packaging uses prebuilt branded PNG and ICO resources from `build/`, so release builds do not depend on converting the source SVG at package time.
-
-Prepare the current website, Netlify archive, and release post copy:
-
-```powershell
-npm run promotion:prepare
-```
-
-This refreshes versioned download links and sitemap dates, validates the static site, and writes the deployable archive to `artifacts/pc-recap-netlify.zip`. After the updated site is live, notify participating search engines with `npm run seo:submit`.
+All package commands pass `--publish never`. Publishing is handled only by the tag-driven release workflow after every platform artifact has been built and verified.
 
 ## Architecture
 
 ```text
 Windows / macOS / Linux activity source
-                 |
-ActivityTracker + performance sampler
-                 |
- SQLite raw history + hourly/daily rollups + portable backups
-                 |
- analytics + deterministic rules
-                 |
- validated Electron IPC -> React renderer
+                 │
+Activity tracker + optional performance sampler
+                 │
+SQLite raw history + hourly/daily rollups + portable backups
+                 │
+Analytics + deterministic observation rules
+                 │
+Allowlisted Electron IPC → React renderer
 ```
 
-- `src/main` — Electron lifecycle, tray, platform activity sources, lightweight performance history, SQLite, historical recovery, backups, and IPC.
-- `src/shared` — domain contracts, period math, analytics, and the deterministic observation engine.
-- `src/renderer` — React UI, archive visualizations, Day Replay, Recap Studio, Memory Pins, and share cards.
-- `website` — dependency-free product and download site for static hosting.
-- `scripts` — activity and website verification utilities.
+- `src/main` contains Electron lifecycle, tray behavior, platform collectors, SQLite, recovery, backups, and secure IPC.
+- `src/shared` contains domain contracts, period math, analytics, and deterministic observations.
+- `src/renderer` contains the React UI, timelines, Day Replay, Recap Studio, Memory Pins, and share cards.
+- `website` is the dependency-free static product and download site.
+- `scripts` contains activity, packaging, release, and website verification tools.
 
-The renderer runs with context isolation, sandboxing, no Node integration, and an explicit preload API. Platform-specific activity collection stays behind the activity-source boundary; all platforms share analytics and persistence.
+Operating-system-specific tracking stays behind the activity-source boundary. All platforms share the same analytics, persistence, and renderer contracts.
 
 ## Contributing
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Activity data must remain local, observations must remain deterministic, and features must behave honestly with an empty archive.
+Issues and pull requests are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md) and [SUPPORT.md](SUPPORT.md). Features must remain honest with an empty archive, activity must remain on-device, and observations must remain deterministic.
+
+If PC Recap is the kind of open-source project you want to see grow, starring the repository helps more people find it.
 
 ## License
 
 Copyright © 2026 Ryan Panda.
 
-PC Recap's source code is licensed under the [GNU General Public License v3.0](LICENSE), using the `GPL-3.0-only` SPDX identifier. You may use, study, modify, and redistribute the code under those terms. Distributed versions must provide the corresponding source and preserve the same license.
-
-The GPL covers the software, not the PC Recap name, logo, or visual identity. Those may be used to refer to the original project, but modified distributions should use distinct branding and must not imply endorsement.
+The source code is licensed under [GNU GPL v3.0](LICENSE) using the `GPL-3.0-only` SPDX identifier. The license covers the software, not the PC Recap name, logo, or visual identity. Modified distributions should use distinct branding and must not imply endorsement.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,30 @@
+# PC Recap support
+
+## Before opening an issue
+
+1. Confirm that you are running the [latest release](https://github.com/TheAgencyMGE/pc-recap/releases/latest).
+2. Open **Settings → Tracking Health** and note the collector status and its explanation.
+3. Read the [install guide](docs/INSTALL.md), especially the macOS permission and Linux X11 notes.
+4. Search [existing issues](https://github.com/TheAgencyMGE/pc-recap/issues) for the same behavior.
+
+## Report a bug
+
+Use the [bug report form](https://github.com/TheAgencyMGE/pc-recap/issues/new?template=bug_report.yml). Include:
+
+- PC Recap version.
+- Operating system, version, CPU architecture, and Linux display session when applicable.
+- Clear steps to reproduce the problem.
+- What you expected and what happened instead.
+- Sanitized logs only when they contain no personal activity data.
+
+Do not upload an activity database, `.pcr` backup, window titles, local file paths, or screenshots that expose personal information.
+
+## Request a feature
+
+Use the [feature request form](https://github.com/TheAgencyMGE/pc-recap/issues/new?template=feature_request.yml). Explain the memory or recap you want PC Recap to preserve and how it should behave with an empty or incomplete archive.
+
+## Security reports
+
+Do not report vulnerabilities in a public issue. Follow [SECURITY.md](SECURITY.md) and use GitHub's private vulnerability reporting flow.
+
+PC Recap is maintained as an open-source project. Response times are not guaranteed, but reproducible reports and focused pull requests are welcome.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,74 @@
+# Install PC Recap
+
+Download PC Recap only from the [official GitHub Releases page](https://github.com/TheAgencyMGE/pc-recap/releases/latest). Version 1.2 beta packages are unsigned, so your operating system may ask you to confirm that you trust the download.
+
+## Windows 10 and 11
+
+1. Download `PC-Recap-1.2.0-Setup.exe`.
+2. Open the installer.
+3. If Microsoft Defender SmartScreen appears, confirm that the file came from the official PC Recap release, choose **More info**, then choose **Run anyway**.
+4. Choose an installation folder and finish setup.
+
+PC Recap can keep tracking from the system tray after its window closes. Startup launch is optional and can be changed in Settings.
+
+## macOS 12 or newer
+
+Choose the correct DMG:
+
+- Apple Silicon (`arm64`) for M1, M2, M3, M4, and newer Apple silicon Macs.
+- Intel (`x64`) for Intel-based Macs.
+
+Then:
+
+1. Open the downloaded DMG.
+2. Drag PC Recap into **Applications**.
+3. In Applications, Control-click PC Recap and choose **Open**.
+4. If macOS still blocks it, open **System Settings → Privacy & Security**, locate the PC Recap notice, and choose **Open Anyway**.
+5. Approve any foreground-app or automation permission PC Recap explains during onboarding.
+
+The beta is not notarized. You should not disable Gatekeeper system-wide to install it.
+
+## Linux x64
+
+Foreground tracking currently requires an X11 session and the `xprop` command. On Wayland, PC Recap still opens but Tracking Health reports foreground collection as unavailable.
+
+### AppImage
+
+```bash
+chmod +x PC-Recap-1.2.0-linux-x64.AppImage
+./PC-Recap-1.2.0-linux-x64.AppImage
+```
+
+If `xprop` is missing, install the package that provides it for your distribution, such as `x11-utils` on Debian or Ubuntu.
+
+### Debian or Ubuntu
+
+```bash
+sudo apt install ./PC-Recap-1.2.0-linux-x64.deb
+```
+
+## Verify a checksum
+
+Every release asset has a matching `.sha256` file. Download both files from the same release, then compare them locally.
+
+Windows PowerShell:
+
+```powershell
+Get-FileHash .\PC-Recap-1.2.0-Setup.exe -Algorithm SHA256
+Get-Content .\PC-Recap-1.2.0-Setup.exe.sha256
+```
+
+macOS or Linux:
+
+```bash
+shasum -a 256 PC-Recap-1.2.0-mac-arm64.dmg
+cat PC-Recap-1.2.0-mac-arm64.dmg.sha256
+```
+
+The hexadecimal values should match exactly. If they do not, delete the package and download it again from the official release.
+
+## Updating
+
+PC Recap does not auto-update yet. Download the newer package from GitHub Releases and install it over the existing app. Your activity database is stored separately from the application, but making a `.pcr` backup before a beta update is still recommended.
+
+If installation or tracking fails, check the in-app Tracking Health panel and follow [SUPPORT.md](../SUPPORT.md).

--- a/package.json
+++ b/package.json
@@ -17,7 +17,22 @@
     "node": ">=22"
   },
   "type": "module",
-  "description": "A local-first visual time capsule for your PC life.",
+  "description": "An open-source visual app usage tracker and computer history time capsule for Windows, macOS, and Linux.",
+  "keywords": [
+    "activity-tracker",
+    "app-usage",
+    "data-visualization",
+    "desktop-app",
+    "digital-wellbeing",
+    "electron",
+    "lifelogging",
+    "linux",
+    "macos",
+    "personal-analytics",
+    "sqlite",
+    "time-tracker",
+    "windows"
+  ],
   "main": "dist/main/main.js",
   "scripts": {
     "dev": "npm run build:main && concurrently -k \"vite --host 127.0.0.1\" \"tsc -p tsconfig.main.json --watch --preserveWatchOutput\" \"esbuild ./src/main/preload.ts --bundle --platform=node --format=cjs --external:electron --outfile=dist/main/preload.cjs --watch\" \"wait-on tcp:127.0.0.1:5173 dist/main/main.js dist/main/preload.cjs && cross-env VITE_DEV_SERVER_URL=http://127.0.0.1:5173 electron .\"",
@@ -27,7 +42,7 @@
     "smoke:visual": "node scripts/visual-smoke.mjs",
     "smoke:visual:test": "node --test scripts/visual-smoke.test.mjs",
     "website:validate": "node scripts/validate-website.mjs",
-    "promotion:test": "node --test scripts/prepare-promotion.test.mjs scripts/submit-indexnow.test.mjs",
+    "promotion:test": "node --test scripts/prepare-promotion.test.mjs scripts/submit-indexnow.test.mjs scripts/website-motion.test.mjs",
     "promotion:prepare": "node scripts/prepare-promotion.mjs && npm run website:validate",
     "seo:submit": "node scripts/submit-indexnow.mjs",
     "release:inspect": "node scripts/verify-installer.mjs",

--- a/scripts/prepare-promotion.mjs
+++ b/scripts/prepare-promotion.mjs
@@ -75,11 +75,9 @@ async function main() {
       `${platform} download links`,
     );
   }
-  html = replaceRequired(
-    html,
+  html = html.replace(
     /v\d+\.\d+\.\d+ beta(?: · x64)?/,
     `v${metadata.version} beta`,
-    'visible release label',
   );
   html = replaceRequired(
     html,

--- a/scripts/validate-website.mjs
+++ b/scripts/validate-website.mjs
@@ -5,7 +5,7 @@ import { extname, resolve } from 'node:path';
 
 const site = resolve('website');
 const required = [
-  'index.html', 'styles.css', 'site.js', 'analytics.js', '_headers', 'robots.txt', 'og.png',
+  'index.html', 'styles.css', 'site.js', 'motion.js', 'analytics.js', '_headers', 'robots.txt', 'og.png',
   'favicon.svg', 'manifest.webmanifest', 'sitemap.xml', 'indexnow-key.txt',
   'THIRD_PARTY_NOTICES.txt', 'fonts/archivo.woff2', 'fonts/instrument-sans.woff2',
   'fonts/OFL-Archivo.txt', 'fonts/OFL-Instrument-Sans.txt',
@@ -19,6 +19,7 @@ for (const file of required) await access(resolve(site, file));
 const html = await readFile(resolve(site, 'index.html'), 'utf8');
 const headers = await readFile(resolve(site, '_headers'), 'utf8');
 const script = await readFile(resolve(site, 'site.js'), 'utf8');
+const motion = await readFile(resolve(site, 'motion.js'), 'utf8');
 const analytics = await readFile(resolve(site, 'analytics.js'), 'utf8');
 const robots = await readFile(resolve(site, 'robots.txt'), 'utf8');
 const sitemap = await readFile(resolve(site, 'sitemap.xml'), 'utf8');
@@ -32,7 +33,7 @@ assert.match(html, /<title>PC Recap/i, 'The page needs product-specific metadata
 assert.match(html, /<link rel="canonical" href="https:\/\/pcrecap\.online\/"\s*\/>/i, 'The page needs a canonical production URL.');
 assert.match(html, /<link rel="icon" href="favicon\.svg" type="image\/svg\+xml"\s*\/>/i, 'The page needs its branded favicon.');
 assert.match(html, /<link rel="manifest" href="manifest\.webmanifest"\s*\/>/i, 'The page needs its web app manifest.');
-assert.match(html, /<meta name="robots" content="index, follow, max-image-preview:large"\s*\/>/i, 'The page needs explicit search preview guidance.');
+assert.match(html, /<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"\s*\/>/i, 'The page needs explicit search preview guidance.');
 assert.match(html, /property="og:image"/i, 'The page needs a social preview image.');
 assert.match(html, /property="og:url" content="https:\/\/pcrecap\.online\/"/i, 'The social preview needs the production URL.');
 assert.match(html, /property="og:image" content="https:\/\/pcrecap\.online\/og\.png"/i, 'The social preview must use an absolute image URL.');
@@ -40,6 +41,12 @@ assert.match(html, /name="twitter:image" content="https:\/\/pcrecap\.online\/og\
 assert.match(html, /<script type="application\/ld\+json">\s*\{[\s\S]*"@type":\s*"SoftwareApplication"[\s\S]*<\/script>/i, 'The page needs SoftwareApplication structured data.');
 const structuredData = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/i)?.[1];
 assert.ok(structuredData, 'The structured data block must be readable.');
+const schema = JSON.parse(structuredData);
+const softwareSchema = schema['@graph']?.find((entry) => entry['@type'] === 'SoftwareApplication');
+assert.ok(softwareSchema, 'The structured data must identify PC Recap as software.');
+assert.match(softwareSchema.operatingSystem, /Windows/i, 'Structured data must advertise Windows support.');
+assert.match(softwareSchema.operatingSystem, /macOS/i, 'Structured data must advertise macOS support.');
+assert.match(softwareSchema.operatingSystem, /Linux/i, 'Structured data must advertise Linux support.');
 const structuredDataHash = createHash('sha256').update(structuredData).digest('base64');
 assert.ok(headers.includes(`'sha256-${structuredDataHash}'`), 'The content security policy must allow the exact structured-data block.');
 assert.ok(html.includes(releaseUrl), `The primary download must use the v${metadata.version} GitHub Release asset.`);
@@ -53,12 +60,16 @@ assert.match(headers, /Content-Security-Policy:/i);
 assert.match(headers, /X-Content-Type-Options:\s*nosniff/i);
 assert.match(headers, /Referrer-Policy:/i);
 assert.match(script, /prefers-reduced-motion/);
+assert.match(script, /scrollProgress/, 'The site must drive its recap story from scroll position.');
+assert.match(script, /entry\.target\.classList\.toggle\('is-visible'/, 'Reveal scenes must be able to enter and leave with the viewport.');
+assert.match(motion, /export function storyFrame/, 'Scroll motion math must remain independently testable.');
 assert.match(html, /<script async src="https:\/\/plausible\.io\/js\/pa-XHVFKtgOfFWCJGGT6QqaS\.js"><\/script>/, 'The Plausible site tracker must load.');
 assert.match(analytics, /plausible\.init\(\)/, 'Plausible must be initialized before it loads.');
 assert.match(headers, /script-src[^\r\n]*https:\/\/plausible\.io/i, 'The content security policy must allow the Plausible tracker.');
 assert.match(headers, /connect-src[^\r\n]*https:\/\/plausible\.io/i, 'The content security policy must allow Plausible events.');
 assert.match(robots, /Sitemap:\s*https:\/\/pcrecap\.online\/sitemap\.xml/i, 'robots.txt must advertise the sitemap.');
 assert.match(sitemap, /<loc>https:\/\/pcrecap\.online\/<\/loc>/i, 'The sitemap must include the canonical home page.');
+assert.match(sitemap, /<image:loc>https:\/\/pcrecap\.online\/og\.png<\/image:loc>/i, 'The sitemap must expose the real product preview to image search.');
 assert.equal(manifest.name, 'PC Recap', 'The manifest must use the product name.');
 assert.match(manifest.description, /Windows/i, 'The manifest must describe Windows support.');
 assert.match(manifest.description, /macOS/i, 'The manifest must describe macOS support.');
@@ -74,6 +85,7 @@ for (const [index, link] of installerLinks.entries()) {
 assert.match(script, /plausible\('Download'/, 'Installer clicks must emit the Download event.');
 assert.match(script, /platform:\s*link\.dataset\.platform/, 'Download events must identify the selected platform.');
 assert.match(html, /aria-label="Download installer SHA-256 checksum"/i, 'The checksum link needs an accessible name.');
+assert.match(html, /<img\s+src="og\.png"[^>]+alt="[^"]+"/i, 'The product preview must be a crawlable image with meaningful alt text.');
 assert.deepEqual([...png.subarray(0, 8)], [137, 80, 78, 71, 13, 10, 26, 10], 'og.png must be a real PNG.');
 const ogWidth = png.readUInt32BE(16);
 const ogHeight = png.readUInt32BE(20);

--- a/scripts/website-motion.test.mjs
+++ b/scripts/website-motion.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { scrollProgress, storyFrame } from '../website/motion.js';
+
+test('scrollProgress maps the sticky story from entering to leaving the viewport', () => {
+  assert.equal(scrollProgress({ top: 900, height: 4000, viewportHeight: 900 }), 0);
+  assert.equal(scrollProgress({ top: 0, height: 4000, viewportHeight: 900 }), 0);
+  assert.equal(scrollProgress({ top: -1550, height: 4000, viewportHeight: 900 }), 0.5);
+  assert.equal(scrollProgress({ top: -3100, height: 4000, viewportHeight: 900 }), 1);
+  assert.equal(scrollProgress({ top: -6000, height: 4000, viewportHeight: 900 }), 1);
+});
+
+test('storyFrame moves smoothly between chapters while keeping one chapter active', () => {
+  const opening = storyFrame(0, 4);
+  assert.equal(opening.chapter, 0);
+  assert.deepEqual(opening.cards[0], {
+    distance: 0,
+    opacity: 1,
+    rotate: 0,
+    scale: 1,
+    x: 0,
+    y: 0,
+    z: 4,
+  });
+
+  const midpoint = storyFrame(0.5, 4);
+  assert.equal(midpoint.chapter, 2);
+  assert.equal(midpoint.cards[1].distance, -0.5);
+  assert.equal(midpoint.cards[2].distance, 0.5);
+  assert.equal(midpoint.cards[1].opacity, midpoint.cards[2].opacity);
+
+  const ending = storyFrame(1, 4);
+  assert.equal(ending.chapter, 3);
+  assert.equal(ending.cards[3].opacity, 1);
+  assert.equal(ending.cards[3].y, 0);
+});
+
+test('storyFrame clamps bad progress and supports a single-card story', () => {
+  assert.equal(storyFrame(-5, 1).chapter, 0);
+  assert.equal(storyFrame(12, 1).cards[0].opacity, 1);
+  assert.deepEqual(storyFrame(Number.NaN, 0), { chapter: 0, cards: [] });
+});

--- a/website/_headers
+++ b/website/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-VW1+oaNVYUm7M7bVH7Nouok21G2p/GOh3T3KhcMt9bM=' https://plausible.io; style-src 'self'; img-src 'self'; font-src 'self'; connect-src https://plausible.io; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-F908P0zx62Y83+QPsCw2QUzjEoo6ri0RDazabneXGVU=' https://plausible.io; style-src 'self'; img-src 'self'; font-src 'self'; connect-src https://plausible.io; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'none'; upgrade-insecure-requests
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin

--- a/website/index.html
+++ b/website/index.html
@@ -3,10 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#f6f6f1" />
+    <meta name="theme-color" content="#f4f2ea" />
+    <meta name="color-scheme" content="light" />
     <meta name="application-name" content="PC Recap" />
-    <meta name="robots" content="index, follow, max-image-preview:large" />
-    <meta name="description" content="PC Recap turns real app activity into visual daily, weekly, monthly, and yearly recaps on Windows, macOS, and Linux." />
+    <meta name="author" content="Ryan Panda" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="description" content="PC Recap is a free, open-source app usage tracker that turns your computer history into visual daily, weekly, monthly, and yearly recaps on Windows, macOS, and Linux." />
     <link rel="canonical" href="https://pcrecap.online/" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <link rel="manifest" href="manifest.webmanifest" />
@@ -14,76 +16,112 @@
     <meta property="og:site_name" content="PC Recap" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:url" content="https://pcrecap.online/" />
-    <meta property="og:title" content="PC Recap — Your PC, remembered." />
-    <meta property="og:description" content="Turn your computer activity into visual recaps, eras, records, and a history you can replay." />
+    <meta property="og:title" content="PC Recap — Your computer life, played back." />
+    <meta property="og:description" content="Turn real app usage into visual recaps, eras, records, and a computer history you can replay." />
     <meta property="og:image" content="https://pcrecap.online/og.png" />
-    <meta property="og:image:alt" content="PC Recap visual recap covers for Today, This Week, 2026, Timeline, and On This Day" />
+    <meta property="og:image:secure_url" content="https://pcrecap.online/og.png" />
+    <meta property="og:image:alt" content="A colorful shelf of PC Recap covers for Today, This Week, 2026, Timeline, and On This Day" />
     <meta property="og:image:width" content="1731" />
     <meta property="og:image:height" content="909" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="PC Recap — Your PC, remembered." />
-    <meta name="twitter:description" content="Turn your computer activity into visual recaps, eras, records, and a history you can replay." />
+    <meta name="twitter:title" content="PC Recap — Your computer life, played back." />
+    <meta name="twitter:description" content="A free, open-source visual time capsule for your computer history." />
     <meta name="twitter:image" content="https://pcrecap.online/og.png" />
-    <meta name="twitter:image:alt" content="PC Recap visual recap covers" />
-    <title>PC Recap — Visual Computer History for Windows, macOS &amp; Linux</title>
+    <meta name="twitter:image:alt" content="A colorful shelf of PC Recap covers" />
+    <title>PC Recap | Visual App Usage Tracker for Windows, macOS &amp; Linux</title>
     <link rel="preload" href="fonts/archivo.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="fonts/instrument-sans.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href="styles.css" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
-        "@type": "SoftwareApplication",
-        "name": "PC Recap",
-        "url": "https://pcrecap.online/",
-        "description": "PC Recap turns real app activity into daily, weekly, monthly, and yearly visual recaps, timelines, eras, records, and local performance context.",
-        "applicationCategory": "UtilitiesApplication",
-        "operatingSystem": "Windows, macOS, Linux",
-        "softwareVersion": "1.2.0",
-        "downloadUrl": "https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-Setup.exe",
-        "releaseNotes": "https://github.com/TheAgencyMGE/pc-recap/releases/tag/v1.2.0",
-        "codeRepository": "https://github.com/TheAgencyMGE/pc-recap",
-        "license": "https://www.gnu.org/licenses/gpl-3.0.html",
-        "image": "https://pcrecap.online/og.png",
-        "isAccessibleForFree": true,
-        "offers": {
-          "@type": "Offer",
-          "price": "0",
-          "priceCurrency": "USD"
-        },
-        "author": {
-          "@type": "Person",
-          "name": "Ryan Panda"
-        }
+        "@graph": [
+          {
+            "@type": "WebSite",
+            "@id": "https://pcrecap.online/#website",
+            "url": "https://pcrecap.online/",
+            "name": "PC Recap",
+            "description": "A visual time capsule for your computer history.",
+            "inLanguage": "en-US"
+          },
+          {
+            "@type": "SoftwareApplication",
+            "@id": "https://pcrecap.online/#app",
+            "name": "PC Recap",
+            "url": "https://pcrecap.online/",
+            "mainEntityOfPage": { "@id": "https://pcrecap.online/#website" },
+            "description": "PC Recap is a free, open-source desktop app that turns real application activity into daily, weekly, monthly, yearly, and long-term visual recaps.",
+            "applicationCategory": "UtilitiesApplication",
+            "applicationSubCategory": "Personal analytics and digital memory",
+            "operatingSystem": "Windows 10, Windows 11, macOS 12 or newer, Linux X11",
+            "softwareVersion": "1.2.0",
+            "downloadUrl": "https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-Setup.exe",
+            "releaseNotes": "https://github.com/TheAgencyMGE/pc-recap/releases/tag/v1.2.0",
+            "codeRepository": "https://github.com/TheAgencyMGE/pc-recap",
+            "license": "https://www.gnu.org/licenses/gpl-3.0.html",
+            "image": "https://pcrecap.online/og.png",
+            "screenshot": {
+              "@type": "ImageObject",
+              "url": "https://pcrecap.online/og.png",
+              "width": 1731,
+              "height": 909,
+              "caption": "PC Recap cover shelf and recap modes"
+            },
+            "featureList": [
+              "Foreground application tracking",
+              "Daily, weekly, monthly, yearly, all-time, and decade recaps",
+              "Historical timeline and On This Day",
+              "Deterministic observations, records, and eras",
+              "Local SQLite history and portable backups"
+            ],
+            "isAccessibleForFree": true,
+            "offers": {
+              "@type": "Offer",
+              "price": "0",
+              "priceCurrency": "USD"
+            },
+            "author": {
+              "@type": "Person",
+              "name": "Ryan Panda"
+            }
+          }
+        ]
       }
     </script>
     <script src="analytics.js"></script>
     <script async src="https://plausible.io/js/pa-XHVFKtgOfFWCJGGT6QqaS.js"></script>
-    <script src="site.js" defer></script>
+    <script type="module" src="site.js"></script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
-    <header class="site-header">
+
+    <header class="site-header" data-header>
       <a class="brand" href="#top" aria-label="PC Recap home">
         <span class="brand__stamp" aria-hidden="true">PC</span>
         <span class="brand__name"><b>PC</b><em>RECAP</em></span>
       </a>
-      <a class="header-download" data-download-location="header-windows" data-platform="windows" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-Setup.exe">Download</a>
+      <nav class="site-nav" aria-label="Main navigation">
+        <a href="#recaps">Recaps</a>
+        <a href="#version">Version 1.2</a>
+        <a href="https://github.com/TheAgencyMGE/pc-recap">GitHub</a>
+      </nav>
+      <a class="header-download" href="#download">Download</a>
     </header>
 
     <main id="main">
       <section class="hero" id="top">
-        <div class="hero__copy reveal">
-          <p class="overline">Windows · macOS · Linux</p>
-          <h1>Your PC,<br /><em>remembered.</em></h1>
-          <p class="hero__lede">See the apps, eras, and late nights that made up your year.</p>
+        <div class="hero__copy">
+          <p class="overline hero__overline">Open source · Windows · macOS · Linux</p>
+          <h1>Your computer life,<br /><em>played back.</em></h1>
+          <p class="hero__lede">PC Recap turns real app usage into visual daily, weekly, monthly, and yearly recaps. It remembers the eras, late nights, and strange little patterns that made the time yours.</p>
           <div class="hero__actions">
             <a class="download-button" data-download-location="hero-windows" data-platform="windows" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-Setup.exe">
               <span>Download for Windows</span>
               <span aria-hidden="true">↓</span>
             </a>
-            <span class="release-line">v1.2.0 beta</span>
+            <a class="text-link" href="https://github.com/TheAgencyMGE/pc-recap">View the source <span aria-hidden="true">↗</span></a>
           </div>
-          <div class="platform-links" aria-label="Other downloads">
+          <div class="platform-links" aria-label="Downloads for other operating systems">
             <a data-download-location="hero-mac-arm64" data-platform="mac-arm64" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-mac-arm64.dmg">Mac · Apple Silicon</a>
             <a data-download-location="hero-mac-x64" data-platform="mac-x64" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-mac-x64.dmg">Mac · Intel</a>
             <a data-download-location="hero-linux-appimage" data-platform="linux-appimage" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-linux-x64.AppImage">Linux · AppImage</a>
@@ -91,83 +129,167 @@
           </div>
         </div>
 
-        <div class="today-cover reveal" aria-label="An abstract preview of the Today recap">
-          <div class="today-cover__rings" aria-hidden="true"><i></i><i></i><i></i></div>
-          <div class="today-cover__copy"><span>Today</span><strong>Once you’ve lived it.</strong></div>
-          <div class="today-cover__activity" aria-hidden="true"></div>
-          <div class="today-cover__badge" aria-hidden="true">≋</div>
+        <div class="mixtape-stage" aria-label="A moving stack of PC Recap covers">
+          <article class="hero-cover hero-cover--today"><span>Today</span><strong>Once you’ve<br />lived it.</strong><i aria-hidden="true"></i></article>
+          <article class="hero-cover hero-cover--week"><span>This week</span><strong>Your<br />rhythm.</strong><i aria-hidden="true">7</i></article>
+          <article class="hero-cover hero-cover--year"><span>2026</span><strong>The whole<br />story.</strong><i aria-hidden="true">↗</i></article>
+          <article class="hero-cover hero-cover--memory"><span>On this day</span><strong>It comes<br />back.</strong><i aria-hidden="true">◌</i></article>
+          <div class="mixtape-stage__stamp" aria-hidden="true">YOUR<br />PC</div>
+        </div>
+
+        <a class="scroll-cue" href="#recaps"><span>Scroll through your history</span><i aria-hidden="true">↓</i></a>
+      </section>
+
+      <div class="recap-ticker" aria-hidden="true">
+        <div><span>TODAY</span><i>✳</i><span>WEEK</span><i>✳</i><span>MONTH</span><i>✳</i><span>YEAR</span><i>✳</i><span>ALL-TIME</span><i>✳</i><span>ON THIS DAY</span><i>✳</i><span>TODAY</span><i>✳</i><span>WEEK</span><i>✳</i><span>MONTH</span><i>✳</i><span>YEAR</span><i>✳</i><span>ALL-TIME</span><i>✳</i><span>ON THIS DAY</span><i>✳</i></div>
+      </div>
+
+      <section class="memory-intro" id="recaps" data-reveal>
+        <p class="overline">A digital time capsule</p>
+        <h2>Most trackers tell you where the time went.<br /><em>PC Recap remembers what it felt like.</em></h2>
+      </section>
+
+      <section class="scroll-story" data-scroll-story aria-labelledby="story-title">
+        <div class="scroll-story__sticky">
+          <div class="story-copy">
+            <p class="overline">Your archive, in motion</p>
+            <h2 id="story-title" class="sr-only">How PC Recap turns computer activity into a history</h2>
+            <article class="story-copy__chapter is-active" data-story-copy>
+              <span>Today</span>
+              <h3>A day becomes<br />a pattern.</h3>
+              <p>Your first app. Your last session. The shape of every hour between.</p>
+            </article>
+            <article class="story-copy__chapter" data-story-copy>
+              <span>Eras</span>
+              <h3>Patterns become<br />chapters.</h3>
+              <p>The Minecraft phase. The coding run. The app that quietly disappeared.</p>
+            </article>
+            <article class="story-copy__chapter" data-story-copy>
+              <span>Observations</span>
+              <h3>The odd details<br />survive.</h3>
+              <p>Your 2 AM app. Your power couple. Your computer’s hardest-working moment.</p>
+            </article>
+            <article class="story-copy__chapter" data-story-copy>
+              <span>Yearly Recap</span>
+              <h3>Then the year<br />plays back.</h3>
+              <p>A full-screen story of favorites, records, monthly eras, and the facts only your computer could know.</p>
+            </article>
+            <div class="story-meter" aria-hidden="true"><i></i><i></i><i></i><i></i></div>
+          </div>
+
+          <div class="story-deck" aria-hidden="true">
+            <article class="story-card story-card--day" data-story-card>
+              <span>Today</span>
+              <b>Your day,<br />in tracks.</b>
+              <div class="story-card__tape"><i></i><i></i><i></i><i></i></div>
+              <small>FIRST → LAST</small>
+            </article>
+            <article class="story-card story-card--era" data-story-card>
+              <span>Era detected</span>
+              <b>Your<br />chapter.</b>
+              <i class="story-card__orbit"></i>
+              <small>MONTHS BECOME ERAS</small>
+            </article>
+            <article class="story-card story-card--pair" data-story-card>
+              <span>Power couple</span>
+              <b>Better<br />together.</b>
+              <div class="story-card__pair"><i></i><i></i></div>
+              <small>APPS USED TOGETHER</small>
+            </article>
+            <article class="story-card story-card--year" data-story-card>
+              <span>Yearly Recap</span>
+              <b>Your year.<br />One more time.</b>
+              <i class="story-card__burst">↗</i>
+              <small>PLAY YOUR RECAP</small>
+            </article>
+          </div>
         </div>
       </section>
 
-      <section class="recap-section" aria-labelledby="recaps-title">
-        <div class="section-heading reveal">
-          <h2 id="recaps-title">Your recaps</h2>
-          <p>Days become years.</p>
+      <section class="recap-gallery" aria-labelledby="gallery-title">
+        <div class="gallery-heading" data-reveal>
+          <p class="overline">Every scale of your history</p>
+          <h2 id="gallery-title">Days become years.</h2>
         </div>
-        <div class="recap-shelf reveal" role="list" aria-label="PC Recap recap formats">
-          <article class="recap-card recap-card--today" role="listitem"><span class="card-icon">⌁</span><div><b>Today</b><small>Your day</small></div></article>
-          <article class="recap-card recap-card--week" role="listitem"><span class="card-icon">7</span><div><b>This week</b><small>The rhythm</small></div></article>
-          <article class="recap-card recap-card--year" role="listitem"><span class="card-icon">↗</span><div><b>2026</b><small>The story</small></div></article>
-          <article class="recap-card recap-card--timeline" role="listitem"><span class="card-icon">∞</span><div><b>Timeline</b><small>The long view</small></div></article>
-          <article class="recap-card recap-card--memory" role="listitem"><span class="card-icon">◌</span><div><b>On this day</b><small>The return</small></div></article>
-        </div>
-      </section>
-
-      <section class="story" aria-labelledby="story-title">
-        <div class="story__copy reveal">
-          <p class="overline">Yearly Recap</p>
-          <h2 id="story-title">Your year,<br /><em>one screen at a time.</em></h2>
-        </div>
-        <div class="story__scenes reveal" aria-label="Yearly Recap scene types">
-          <article class="scene scene--favorite"><span>Top app</span><b>Your favorite</b><i aria-hidden="true"></i></article>
-          <article class="scene scene--era"><span>Era</span><b>Your chapter</b><i aria-hidden="true">ERA</i></article>
-          <article class="scene scene--fact"><span>Observation</span><b>Your weird fact</b><i aria-hidden="true">“</i></article>
-          <article class="scene scene--system"><span>Computer pulse</span><b>Your hardest-working moment</b><i aria-hidden="true">∿</i></article>
+        <div class="recap-shelf" role="list">
+          <article class="recap-card recap-card--today" role="listitem" data-reveal><span>Today</span><b>The day</b><i aria-hidden="true">⌁</i></article>
+          <article class="recap-card recap-card--week" role="listitem" data-reveal><span>This week</span><b>The rhythm</b><i aria-hidden="true">7</i></article>
+          <article class="recap-card recap-card--month" role="listitem" data-reveal><span>This month</span><b>The shift</b><i aria-hidden="true">30</i></article>
+          <article class="recap-card recap-card--year" role="listitem" data-reveal><span>This year</span><b>The story</b><i aria-hidden="true">↗</i></article>
+          <article class="recap-card recap-card--timeline" role="listitem" data-reveal><span>Timeline</span><b>The long view</b><i aria-hidden="true">∞</i></article>
+          <article class="recap-card recap-card--on-this-day" role="listitem" data-reveal><span>On this day</span><b>The return</b><i aria-hidden="true">◌</i></article>
         </div>
       </section>
 
-      <section class="release-notes reveal" aria-labelledby="release-title">
-        <div><p class="overline">Version 1.2</p><h2 id="release-title">More of your computer story.</h2></div>
-        <article><b>Cross-platform</b><span>Foreground tracking on Windows, macOS, and Linux X11.</span></article>
-        <article><b>Better time</b><span>Active, idle, locked, asleep, and unavailable time stay distinct.</span></article>
-        <article><b>Computer pulse</b><span>Optional local CPU, memory, battery, and power context for recaps.</span></article>
-      </section>
-
-      <section class="principles" aria-label="Product principles">
-        <article class="reveal"><span>01</span><h3>Real history</h3><p>No generated activity.</p></article>
-        <article class="reveal"><span>02</span><h3>Your machine</h3><p>SQLite and portable backups.</p></article>
-        <article class="reveal"><span>03</span><h3>Deterministic</h3><p>No external AI APIs.</p></article>
-      </section>
-
-      <section class="download-panel reveal" aria-labelledby="download-title">
+      <section class="not-timesheet" data-reveal>
         <div>
+          <p class="overline">Built for remembering</p>
+          <h2>A time capsule.<br /><em>Not a time sheet.</em></h2>
+        </div>
+        <div class="not-timesheet__copy">
+          <p>There are no productivity scores waiting to judge you. PC Recap keeps the parts worth looking back on: favorites, records, streaks, eras, reunions, and the little facts you would otherwise forget.</p>
+          <a class="text-link" href="https://github.com/TheAgencyMGE/pc-recap#what-pc-recap-remembers">See what it remembers <span aria-hidden="true">↗</span></a>
+        </div>
+      </section>
+
+      <section class="product-window" aria-labelledby="product-title" data-reveal>
+        <div class="product-window__bar"><i></i><i></i><i></i><span>PC RECAP / COVER SHELF</span></div>
+        <figure>
+          <img src="og.png" width="1731" height="909" loading="lazy" alt="PC Recap’s colorful cover shelf with Today, This Week, Yearly Recap, Timeline, and On This Day views" />
+          <figcaption>
+            <p class="overline">The app</p>
+            <h2 id="product-title">Your history has a home.</h2>
+            <p>Search it. Replay a day. Build a custom recap. Carry the archive to your next computer.</p>
+          </figcaption>
+        </figure>
+      </section>
+
+      <section class="release-board" id="version" aria-labelledby="release-title">
+        <div class="release-board__title" data-reveal>
+          <p class="overline">Version 1.2</p>
+          <h2 id="release-title">Now your Mac<br />and Linux PC<br />remember too.</h2>
+          <span>Windows · macOS · Linux X11</span>
+        </div>
+        <div class="release-board__notes">
+          <article data-reveal><span>01</span><div><b>Tracking Health</b><p>See the collector, current state, permissions, and last successful sample.</p></div></article>
+          <article data-reveal><span>02</span><div><b>Computer pulse</b><p>Optional CPU, memory, battery, and power context for the moments that pushed your system.</p></div></article>
+          <article data-reveal><span>03</span><div><b>Honest time</b><p>Active, idle, locked, asleep, and unavailable time stay separate.</p></div></article>
+          <article data-reveal><span>04</span><div><b>Long-haul archive</b><p>Faster analytics, daily backups, merge previews, and storage built for years of history.</p></div></article>
+        </div>
+      </section>
+
+      <section class="principles" aria-label="PC Recap principles">
+        <article data-reveal><span>REAL</span><h3>No invented activity.</h3><p>A new archive starts empty and grows from real sessions or imports.</p></article>
+        <article data-reveal><span>LOCAL</span><h3>Your history stays here.</h3><p>SQLite on your computer, portable backups when you want them.</p></article>
+        <article data-reveal><span>OPEN</span><h3>Read the source.</h3><p>GPL-3.0 code, deterministic rules, and no external AI calls.</p></article>
+      </section>
+
+      <section class="download-panel" id="download" aria-labelledby="download-title" data-reveal>
+        <div class="download-panel__intro">
           <p class="overline">PC Recap 1.2.0 Beta</p>
-          <h2 id="download-title">Start your archive.</h2>
+          <h2 id="download-title">Start the archive.</h2>
+          <p>Choose your computer. Each build is free and open source.</p>
         </div>
-        <a class="download-button download-button--light" data-download-location="footer-panel-windows" data-platform="windows" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-Setup.exe">
-          <span>Download for Windows</span>
-          <span aria-hidden="true">↓</span>
-        </a>
-        <div class="download-platforms" aria-label="Downloads for every platform">
-          <a data-download-location="footer-mac-arm64" data-platform="mac-arm64" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-mac-arm64.dmg"><b>macOS</b><span>Apple Silicon</span></a>
-          <a data-download-location="footer-mac-x64" data-platform="mac-x64" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-mac-x64.dmg"><b>macOS</b><span>Intel</span></a>
-          <a data-download-location="footer-linux-appimage" data-platform="linux-appimage" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-linux-x64.AppImage"><b>Linux</b><span>AppImage x64</span></a>
-          <a data-download-location="footer-linux-deb" data-platform="linux-deb" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-linux-x64.deb"><b>Linux</b><span>deb x64</span></a>
+        <div class="download-grid">
+          <a data-download-location="download-windows" data-platform="windows" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-Setup.exe"><span>Windows</span><b>x64 installer</b><i aria-hidden="true">↓</i></a>
+          <a data-download-location="download-mac-arm64" data-platform="mac-arm64" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-mac-arm64.dmg"><span>macOS</span><b>Apple Silicon</b><i aria-hidden="true">↓</i></a>
+          <a data-download-location="download-mac-x64" data-platform="mac-x64" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-mac-x64.dmg"><span>macOS</span><b>Intel</b><i aria-hidden="true">↓</i></a>
+          <a data-download-location="download-linux-appimage" data-platform="linux-appimage" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-linux-x64.AppImage"><span>Linux</span><b>AppImage x64</b><i aria-hidden="true">↓</i></a>
+          <a data-download-location="download-linux-deb" data-platform="linux-deb" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-linux-x64.deb"><span>Linux</span><b>deb x64</b><i aria-hidden="true">↓</i></a>
         </div>
-        <a class="checksum" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-Setup.exe.sha256" aria-label="Download installer SHA-256 checksum">
-          <span>SHA-256</span>
-          <strong>Download checksum</strong>
-          <i aria-hidden="true">→</i>
-        </a>
+        <div class="download-footnote">
+          <span>Unsigned beta builds may trigger Windows SmartScreen or macOS Gatekeeper.</span>
+          <a class="checksum" href="https://github.com/TheAgencyMGE/pc-recap/releases/download/v1.2.0/PC-Recap-1.2.0-Setup.exe.sha256" aria-label="Download installer SHA-256 checksum">SHA-256 checksum <i aria-hidden="true">→</i></a>
+        </div>
       </section>
     </main>
 
     <footer>
       <a class="brand brand--small" href="#top"><span class="brand__stamp" aria-hidden="true">PC</span><span>PC Recap</span></a>
-      <nav aria-label="Footer">
-        <a href="https://github.com/TheAgencyMGE/pc-recap">Open source</a>
-        <a href="https://github.com/TheAgencyMGE/pc-recap/blob/main/SECURITY.md">Security</a>
+      <nav aria-label="Footer navigation">
+        <a href="https://github.com/TheAgencyMGE/pc-recap">Source</a>
         <a href="https://github.com/TheAgencyMGE/pc-recap/releases">Releases</a>
+        <a href="https://github.com/TheAgencyMGE/pc-recap/blob/main/SECURITY.md">Security</a>
         <a href="THIRD_PARTY_NOTICES.txt">Notices</a>
       </nav>
       <span>© 2026 Ryan Panda</span>

--- a/website/motion.js
+++ b/website/motion.js
@@ -1,0 +1,31 @@
+const clamp = (value, minimum = 0, maximum = 1) => Math.min(maximum, Math.max(minimum, value));
+const rounded = (value, precision = 3) => Number(value.toFixed(precision));
+
+export function scrollProgress({ top, height, viewportHeight }) {
+  const travel = Math.max(1, height - viewportHeight);
+  return clamp(-top / travel);
+}
+
+export function storyFrame(progress, cardCount) {
+  const count = Math.max(0, Math.floor(Number.isFinite(cardCount) ? cardCount : 0));
+  if (count === 0) return { chapter: 0, cards: [] };
+
+  const normalized = clamp(Number.isFinite(progress) ? progress : 0);
+  const position = normalized * Math.max(0, count - 1);
+  const chapter = clamp(Math.round(position), 0, count - 1);
+  const cards = Array.from({ length: count }, (_, index) => {
+    const distance = rounded(index - position);
+    const magnitude = Math.abs(distance);
+    return {
+      distance,
+      opacity: rounded(clamp(1 - magnitude * 0.64, 0.12, 1)),
+      rotate: rounded(distance * 7, 2),
+      scale: rounded(1 - Math.min(magnitude, 1) * 0.08),
+      x: rounded(distance * 24, 2),
+      y: rounded(distance * 112, 2),
+      z: Math.max(0, count - Math.round(magnitude)),
+    };
+  });
+
+  return { chapter, cards };
+}

--- a/website/site.js
+++ b/website/site.js
@@ -1,4 +1,15 @@
-document.documentElement.classList.add('js');
+import { scrollProgress, storyFrame } from './motion.js';
+
+const root = document.documentElement;
+const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+const header = document.querySelector('[data-header]');
+const story = document.querySelector('[data-scroll-story]');
+const storyCopies = [...document.querySelectorAll('[data-story-copy]')];
+const storyCards = [...document.querySelectorAll('[data-story-card]')];
+const reveals = [...document.querySelectorAll('[data-reveal]')];
+
+root.classList.add('js');
+requestAnimationFrame(() => root.classList.add('motion-ready'));
 
 for (const link of document.querySelectorAll('[data-download-location]')) {
   link.addEventListener('click', () => {
@@ -12,18 +23,53 @@ for (const link of document.querySelectorAll('[data-download-location]')) {
   });
 }
 
-const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-const reveals = [...document.querySelectorAll('.reveal')];
-
 if (reducedMotion.matches || !('IntersectionObserver' in window)) {
   reveals.forEach((element) => element.classList.add('is-visible'));
 } else {
-  const observer = new IntersectionObserver((entries) => {
+  const revealObserver = new IntersectionObserver((entries) => {
     for (const entry of entries) {
-      if (!entry.isIntersecting) continue;
-      entry.target.classList.add('is-visible');
-      observer.unobserve(entry.target);
+      entry.target.classList.toggle('is-visible', entry.isIntersecting);
     }
-  }, { rootMargin: '0px 0px -8% 0px', threshold: 0.08 });
-  reveals.forEach((element) => observer.observe(element));
+  }, { rootMargin: '-7% 0px -7% 0px', threshold: 0.06 });
+  reveals.forEach((element) => revealObserver.observe(element));
 }
+
+const updateStory = () => {
+  if (!story || reducedMotion.matches) return;
+  const bounds = story.getBoundingClientRect();
+  const progress = scrollProgress({
+    top: bounds.top,
+    height: bounds.height,
+    viewportHeight: window.innerHeight,
+  });
+  const frame = storyFrame(progress, storyCards.length);
+  story.dataset.chapter = String(frame.chapter);
+  storyCopies.forEach((copy, index) => copy.classList.toggle('is-active', index === frame.chapter));
+  storyCards.forEach((card, index) => {
+    const state = frame.cards[index];
+    card.style.setProperty('--card-x', state.x);
+    card.style.setProperty('--card-y', state.y);
+    card.style.setProperty('--card-rotate', state.rotate);
+    card.style.setProperty('--card-scale', state.scale);
+    card.style.setProperty('--card-opacity', state.opacity);
+    card.style.setProperty('--card-z', state.z);
+  });
+};
+
+let frameRequested = false;
+const updatePage = () => {
+  header?.classList.toggle('is-scrolled', window.scrollY > 24);
+  updateStory();
+  frameRequested = false;
+};
+
+const requestPageUpdate = () => {
+  if (frameRequested) return;
+  frameRequested = true;
+  requestAnimationFrame(updatePage);
+};
+
+window.addEventListener('scroll', requestPageUpdate, { passive: true });
+window.addEventListener('resize', requestPageUpdate, { passive: true });
+reducedMotion.addEventListener?.('change', requestPageUpdate);
+requestPageUpdate();

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://pcrecap.online/</loc>
-    <lastmod>2026-08-20</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
+    <image:image>
+      <image:loc>https://pcrecap.online/og.png</image:loc>
+      <image:caption>PC Recap visual app usage tracker cover shelf and recap modes</image:caption>
+    </image:image>
   </url>
 </urlset>

--- a/website/styles.css
+++ b/website/styles.css
@@ -2,192 +2,321 @@
 @font-face { font-family: 'Instrument Sans'; src: url('fonts/instrument-sans.woff2') format('woff2'); font-style: normal; font-weight: 400 700; font-display: swap; }
 
 :root {
-  --paper: #f6f6f1;
-  --white: #fff;
-  --ink: #151515;
-  --muted: #6f706a;
-  --line: #dcdcd5;
-  --red: #ff6038;
-  --yellow: #ffd43b;
-  --lilac: #aa9dff;
-  --cobalt: #4256f4;
-  --acid: #c9f227;
-  --pink: #ff9fc9;
+  --paper: #f4f2ea;
+  --paper-deep: #e9e6dc;
+  --white: #fffefa;
+  --ink: #171717;
+  --muted: #67665f;
+  --line: rgba(23, 23, 23, .18);
+  --red: #ff4f32;
+  --blue: #3957ff;
+  --acid: #c7f000;
+  --lilac: #a99cff;
+  --yellow: #ffd72e;
+  --pink: #ff9fc5;
   --display: 'Archivo', 'Arial Narrow', sans-serif;
   --body: 'Instrument Sans', 'Segoe UI', sans-serif;
+  --page: min(1480px, calc(100% - 64px));
+  --ease: cubic-bezier(.2, .75, .2, 1);
 }
 
 * { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
-body { margin: 0; overflow-x: hidden; background: var(--paper); color: var(--ink); font-family: var(--body); -webkit-font-smoothing: antialiased; }
+html { overflow-x: clip; scroll-behavior: smooth; }
+body { margin: 0; overflow-x: hidden; background: radial-gradient(circle at 18% 12%, rgba(255,255,255,.72), transparent 30%), var(--paper); color: var(--ink); font-family: var(--body); -webkit-font-smoothing: antialiased; }
+body::before { position: fixed; z-index: 100; inset: 0; opacity: .045; background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 160 160' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.8' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.55'/%3E%3C/svg%3E"); content: ''; pointer-events: none; }
 a { color: inherit; text-decoration: none; }
+img { display: block; max-width: 100%; }
 button { color: inherit; font: inherit; }
 .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; padding: 0; border: 0; margin: -1px; clip: rect(0, 0, 0, 0); white-space: nowrap; }
-a:focus-visible, button:focus-visible { outline: 3px solid var(--cobalt); outline-offset: 4px; }
-.skip-link { position: fixed; z-index: 100; top: 12px; left: 12px; padding: 10px 14px; border-radius: 999px; background: var(--ink); color: white; transform: translateY(-160%); }
+a:focus-visible, button:focus-visible { outline: 3px solid var(--blue); outline-offset: 4px; }
+.skip-link { position: fixed; z-index: 200; top: 12px; left: 12px; padding: 11px 16px; border-radius: 999px; background: var(--ink); color: white; transform: translateY(-170%); }
 .skip-link:focus { transform: translateY(0); }
 
-.site-header { position: relative; z-index: 20; display: flex; width: min(1500px, calc(100% - 56px)); height: 88px; align-items: center; justify-content: space-between; margin: 0 auto; }
-.brand { display: inline-flex; align-items: center; gap: 11px; }
-.brand__stamp { display: grid; width: 40px; height: 40px; place-items: center; border-radius: 12px; background: var(--red); font: 900 13px/1 var(--display); transform: rotate(-2deg); }
-.brand__name { display: flex; flex-direction: column; font: 830 14px/.85 var(--display); letter-spacing: -.035em; }
-.brand__name em { font-size: 11px; font-style: normal; letter-spacing: .045em; }
-.header-download { padding: 12px 18px; border-radius: 999px; background: var(--ink); color: white; font-weight: 700; transition: transform .2s ease, background .2s ease; }
-.header-download:hover { background: var(--cobalt); transform: translateY(-2px); }
+.site-header { position: fixed; z-index: 50; top: 16px; left: 50%; display: grid; grid-template-columns: 1fr auto 1fr; width: min(980px, calc(100% - 32px)); min-height: 64px; align-items: center; padding: 8px 10px 8px 12px; border: 1px solid transparent; border-radius: 20px; transform: translateX(-50%); transition: width .35s var(--ease), background .35s ease, border-color .35s ease, box-shadow .35s ease; }
+.site-header.is-scrolled { width: min(900px, calc(100% - 32px)); border-color: var(--line); background: rgba(244,242,234,.88); box-shadow: 0 14px 38px rgba(23,23,23,.1); -webkit-backdrop-filter: blur(16px); backdrop-filter: blur(16px); }
+.brand { display: inline-flex; align-items: center; gap: 10px; justify-self: start; }
+.brand__stamp { display: grid; width: 40px; height: 40px; place-items: center; border-radius: 8px 15px 10px 12px; background: var(--red); font: 900 13px/1 var(--display); letter-spacing: -.04em; transform: rotate(-3deg); }
+.brand__name { display: grid; font: 840 13px/.76 var(--display); letter-spacing: -.04em; }
+.brand__name em { font-size: 10px; font-style: normal; letter-spacing: .1em; }
+.site-nav { display: flex; align-items: center; gap: 28px; font-size: 12px; font-weight: 700; }
+.site-nav a { position: relative; padding: 9px 0; }
+.site-nav a::after { position: absolute; right: 0; bottom: 4px; left: 0; height: 2px; background: var(--ink); content: ''; transform: scaleX(0); transform-origin: right; transition: transform .25s var(--ease); }
+.site-nav a:hover::after { transform: scaleX(1); transform-origin: left; }
+.header-download { justify-self: end; padding: 12px 18px; border-radius: 999px; background: var(--ink); color: white; font-size: 12px; font-weight: 800; transition: background .2s ease, color .2s ease, transform .2s var(--ease); }
+.header-download:hover { background: var(--acid); color: var(--ink); transform: rotate(-2deg); }
 
 main { display: block; }
-.hero, .recap-section, .story, .release-notes, .principles, .download-panel, footer { width: min(1500px, calc(100% - 56px)); margin-right: auto; margin-left: auto; }
-.hero { display: grid; grid-template-columns: minmax(300px, .7fr) minmax(520px, 1.3fr); gap: clamp(36px, 6vw, 96px); align-items: center; min-height: calc(100svh - 88px); padding: 50px 0 100px; }
-.overline { margin: 0 0 22px; color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; }
-.hero h1, .story h2 { margin: 0; font: 850 clamp(68px, 8vw, 126px)/.78 var(--display); letter-spacing: -.075em; }
-.hero h1 em, .story h2 em { font-weight: 440; }
-.hero__lede { max-width: 520px; margin: 32px 0 0; color: #3d3e3a; font-size: clamp(17px, 1.5vw, 21px); line-height: 1.45; }
-.hero__actions { display: flex; align-items: center; gap: 18px; margin-top: 34px; }
-.download-button { display: inline-flex; min-height: 56px; align-items: center; justify-content: space-between; gap: 28px; padding: 0 22px; border-radius: 999px; background: var(--ink); color: white; font-weight: 750; transition: transform .2s ease, background .2s ease, box-shadow .2s ease; }
-.download-button:hover { background: var(--cobalt); box-shadow: 0 12px 28px rgba(66,86,244,.25); transform: translateY(-3px); }
-.download-button span:last-child { font-size: 22px; }
-.release-line { color: var(--muted); font-size: 13px; }
-.platform-links { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 14px; }
-.platform-links a { padding: 7px 10px; border: 1px solid var(--line); border-radius: 999px; color: var(--muted); font-size: 11px; font-weight: 700; transition: border-color .2s ease, color .2s ease, transform .2s ease; }
-.platform-links a:hover { border-color: var(--ink); color: var(--ink); transform: translateY(-1px); }
+.hero, .memory-intro, .recap-gallery, .not-timesheet, .product-window, .release-board, .principles, .download-panel, footer { width: var(--page); margin-right: auto; margin-left: auto; }
+.overline { margin: 0; font-size: 11px; font-weight: 800; letter-spacing: .13em; text-transform: uppercase; }
+.text-link { display: inline-flex; align-items: center; gap: 8px; border-bottom: 1px solid currentColor; padding: 6px 0 4px; font-size: 13px; font-weight: 750; }
+.text-link span { transition: transform .2s var(--ease); }
+.text-link:hover span { transform: translate(3px, -3px); }
 
-.today-cover { position: relative; min-height: clamp(410px, 57vw, 650px); overflow: hidden; border-radius: 36px; background: linear-gradient(90deg, var(--yellow) 0 48%, var(--lilac) 48% 100%); box-shadow: 0 26px 64px rgba(21,21,21,.15); isolation: isolate; }
-.today-cover__rings { position: absolute; z-index: -1; top: -18%; right: -8%; width: 82%; aspect-ratio: 1; }
-.today-cover__rings i { position: absolute; inset: 0; border: clamp(25px, 4vw, 62px) solid rgba(255,255,255,.72); border-radius: 50%; }
-.today-cover__rings i:nth-child(2) { inset: 22%; }
-.today-cover__rings i:nth-child(3) { inset: 43%; }
-.today-cover__copy { position: absolute; bottom: clamp(34px, 5vw, 70px); left: clamp(30px, 5vw, 66px); display: grid; gap: 12px; width: 37%; }
-.today-cover__copy span { font: 760 clamp(21px, 2.2vw, 31px)/1 var(--display); }
-.today-cover__copy strong { font: 820 clamp(36px, 4.4vw, 70px)/.88 var(--display); letter-spacing: -.055em; }
-.today-cover__activity { position: absolute; right: 6%; bottom: 17%; width: 55%; height: 17%; border-radius: 999px; background: var(--cobalt); box-shadow: inset 0 0 0 1px rgba(21,21,21,.06); transform: rotate(-4deg); }
-.today-cover__badge { position: absolute; top: 8%; right: 7%; display: grid; width: 58px; height: 58px; place-items: center; border-radius: 50%; background: white; font: 900 26px var(--display); }
+.hero { position: relative; display: grid; grid-template-columns: minmax(350px,.85fr) minmax(520px,1.15fr); gap: clamp(42px,7vw,112px); align-items: center; min-height: 100svh; padding: 128px 0 96px; }
+.hero__copy { position: relative; z-index: 3; }
+.hero__overline { margin-bottom: 26px; color: var(--muted); }
+.hero h1 { margin: 0; font: 880 clamp(68px,8.2vw,132px)/.76 var(--display); letter-spacing: -.078em; }
+.hero h1 em { font-weight: 420; }
+.hero__lede { max-width: 570px; margin: 34px 0 0; color: #3e3d39; font-size: clamp(17px,1.45vw,21px); line-height: 1.48; }
+.hero__actions { display: flex; align-items: center; gap: 22px; margin-top: 34px; }
+.download-button { display: inline-flex; min-height: 58px; align-items: center; justify-content: space-between; gap: 28px; padding: 0 22px; border-radius: 999px; background: var(--ink); color: white; font-size: 14px; font-weight: 800; transition: background .2s ease, color .2s ease, box-shadow .2s ease, transform .2s var(--ease); }
+.download-button:hover { background: var(--blue); box-shadow: 0 14px 30px rgba(57,87,255,.24); transform: translateY(-3px) rotate(-1deg); }
+.download-button span:last-child { font-size: 20px; }
+.platform-links { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 16px; }
+.platform-links a { padding: 7px 10px; border: 1px solid var(--line); border-radius: 999px; color: var(--muted); font-size: 11px; font-weight: 700; transition: background .2s ease, color .2s ease, transform .2s var(--ease); }
+.platform-links a:hover { background: var(--ink); color: white; transform: translateY(-2px); }
 
-.recap-section { padding: 90px 0 120px; }
-.section-heading { display: flex; align-items: end; justify-content: space-between; gap: 24px; margin-bottom: 26px; }
-.section-heading h2 { margin: 0; font: 790 clamp(34px, 4vw, 54px)/.9 var(--display); letter-spacing: -.05em; }
-.section-heading p { margin: 0; color: var(--muted); }
-.recap-shelf { display: grid; grid-template-columns: repeat(5, minmax(190px, 1fr)); gap: 18px; overflow-x: auto; padding: 0 0 26px; scrollbar-width: none; }
-.recap-shelf::-webkit-scrollbar { display: none; }
-.recap-card { position: relative; display: flex; min-width: 210px; aspect-ratio: .84; flex-direction: column; justify-content: space-between; overflow: hidden; padding: 20px; border-radius: 24px; background: var(--cobalt); color: white; box-shadow: 0 13px 30px rgba(21,21,21,.1); transition: transform .25s cubic-bezier(.2,.8,.2,1); isolation: isolate; }
-.recap-card:hover { transform: translateY(-7px) rotate(-.5deg); }
-.recap-card::before, .recap-card::after { position: absolute; z-index: -1; border-radius: 50%; content: ''; }
-.recap-card::before { top: -12%; right: -28%; width: 76%; aspect-ratio: 1; background: var(--acid); }
-.recap-card::after { right: -12%; bottom: -23%; width: 95%; aspect-ratio: 1; border: 18px solid rgba(255,255,255,.72); }
-.recap-card--week { background: var(--red); color: var(--ink); }
-.recap-card--year { background: var(--ink); }
-.recap-card--year::before { border-radius: 0; background: var(--yellow); transform: rotate(22deg); }
-.recap-card--year::after { border-color: var(--lilac); }
-.recap-card--timeline { background: var(--white); color: var(--ink); }
-.recap-card--timeline::before { background: var(--cobalt); }
-.recap-card--timeline::after { border-color: var(--yellow); }
-.recap-card--memory { border-radius: 50% 50% 24px 24px; background: var(--pink); color: var(--ink); }
-.recap-card--memory::before { background: var(--yellow); }
-.card-icon { display: grid; width: 46px; height: 46px; place-items: center; border-radius: 50%; background: white; color: var(--ink); font: 800 18px/1 var(--display); }
-.recap-card div { display: grid; gap: 4px; }
-.recap-card b { font: 780 clamp(24px, 2.4vw, 35px)/.9 var(--display); letter-spacing: -.045em; }
-.recap-card small { opacity: .72; font-size: 13px; }
+.mixtape-stage { position: relative; min-height: clamp(500px,52vw,730px); perspective: 1100px; }
+.hero-cover { position: absolute; top: 50%; left: 50%; display: flex; width: min(66%,470px); aspect-ratio: .8; flex-direction: column; justify-content: space-between; overflow: hidden; padding: clamp(24px,3vw,38px); border: 1px solid rgba(23,23,23,.22); border-radius: 5% 18% 6% 9%; box-shadow: 0 26px 60px rgba(23,23,23,.17); color: var(--ink); isolation: isolate; }
+.hero-cover span { font-size: 12px; font-weight: 850; letter-spacing: .08em; text-transform: uppercase; }
+.hero-cover strong { font: 840 clamp(38px,4.1vw,64px)/.84 var(--display); letter-spacing: -.055em; }
+.hero-cover i { position: absolute; z-index: -1; font-style: normal; }
+.hero-cover--today { z-index: 4; background: var(--yellow); transform: translate(-67%,-44%) rotate(-9deg); }
+.hero-cover--today i { top: -12%; right: -28%; width: 92%; aspect-ratio: 1; border: clamp(32px,5vw,70px) solid var(--red); border-radius: 50%; }
+.hero-cover--week { z-index: 3; background: var(--lilac); transform: translate(-44%,-51%) rotate(4deg); }
+.hero-cover--week i { right: -3%; bottom: -11%; opacity: .65; color: white; font: 900 clamp(180px,22vw,320px)/.7 var(--display); }
+.hero-cover--year { z-index: 2; background: var(--blue); color: white; transform: translate(-22%,-47%) rotate(12deg); }
+.hero-cover--year::after { position: absolute; z-index: -1; right: -35%; bottom: -7%; width: 105%; aspect-ratio: 1; border: clamp(25px,4vw,58px) solid var(--acid); border-radius: 50%; content: ''; }
+.hero-cover--year i { top: 8%; right: 9%; color: var(--acid); font: 900 44px/1 var(--display); }
+.hero-cover--memory { z-index: 1; background: var(--pink); transform: translate(-2%,-41%) rotate(19deg); }
+.hero-cover--memory i { right: -6%; bottom: -8%; opacity: .6; font: 800 clamp(180px,20vw,300px)/.8 var(--display); }
+.mixtape-stage__stamp { position: absolute; z-index: 8; top: 10%; right: 2%; display: grid; width: 92px; height: 92px; place-items: center; border-radius: 50%; background: var(--acid); box-shadow: 0 8px 20px rgba(23,23,23,.12); font: 900 20px/.8 var(--display); text-align: center; transform: rotate(11deg); }
+.motion-ready .hero-cover { animation: cover-arrive .85s both var(--ease); }
+.motion-ready .hero-cover--today { animation-delay: .18s; }
+.motion-ready .hero-cover--week { animation-delay: .28s; }
+.motion-ready .hero-cover--year { animation-delay: .38s; }
+.motion-ready .hero-cover--memory { animation-delay: .48s; }
+.motion-ready .mixtape-stage__stamp { animation: stamp-arrive .65s .7s both var(--ease); }
+@keyframes cover-arrive { from { opacity: 0; translate: 0 80px; rotate: -8deg; } to { opacity: 1; translate: 0 0; rotate: 0deg; } }
+@keyframes stamp-arrive { from { opacity: 0; transform: scale(.3) rotate(-20deg); } to { opacity: 1; transform: scale(1) rotate(11deg); } }
+.scroll-cue { position: absolute; right: 0; bottom: 26px; display: flex; align-items: center; gap: 16px; color: var(--muted); font-size: 11px; font-weight: 750; text-transform: uppercase; }
+.scroll-cue i { display: grid; width: 40px; height: 40px; place-items: center; border: 1px solid var(--line); border-radius: 50%; color: var(--ink); font-style: normal; }
+.recap-ticker { overflow: hidden; border-top: 1px solid var(--ink); border-bottom: 1px solid var(--ink); background: var(--acid); }
+.recap-ticker > div { display: flex; width: max-content; align-items: center; gap: 26px; padding: 14px 0; animation: ticker 22s linear infinite; }
+.recap-ticker span { font: 850 15px/1 var(--display); letter-spacing: -.02em; }
+.recap-ticker i { font-size: 12px; font-style: normal; }
+@keyframes ticker { to { transform: translateX(-50%); } }
 
-.story { overflow: hidden; padding: clamp(58px, 8vw, 120px); border-radius: 36px; background: var(--ink); color: white; }
-.story__copy { margin-bottom: 70px; }
-.story .overline { color: var(--acid); }
-.story h2 { max-width: 1050px; font-size: clamp(60px, 8vw, 118px); }
-.story__scenes { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
-.scene { position: relative; display: flex; min-height: 270px; flex-direction: column; justify-content: space-between; overflow: hidden; padding: 24px; border-radius: 22px; background: var(--lilac); color: var(--ink); isolation: isolate; }
-.scene span { font-size: 12px; font-weight: 700; text-transform: uppercase; }
-.scene b { max-width: 80%; font: 790 clamp(30px, 3vw, 46px)/.92 var(--display); letter-spacing: -.045em; }
-.scene i { position: absolute; z-index: -1; right: -7%; bottom: -25%; opacity: .16; font: 900 170px/.8 var(--display); font-style: normal; }
-.scene--era { background: var(--acid); }
-.scene--fact { background: var(--red); }
-.scene--system { background: var(--yellow); }
+.memory-intro { padding: clamp(110px,15vw,220px) 0 clamp(90px,12vw,180px); }
+.memory-intro .overline { margin-bottom: 30px; color: var(--red); }
+.memory-intro h2 { max-width: 1270px; margin: 0; font: 820 clamp(50px,7.5vw,112px)/.86 var(--display); letter-spacing: -.067em; }
+.memory-intro h2 em { color: var(--blue); font-weight: 430; }
 
-.release-notes { display: grid; grid-template-columns: minmax(280px, 1.3fr) repeat(3, minmax(180px, .7fr)); gap: 1px; margin-top: 120px; overflow: hidden; border-radius: 26px; background: var(--line); }
-.release-notes > div, .release-notes article { min-width: 0; min-height: 220px; padding: 28px; background: var(--white); }
-.release-notes > div { display: flex; flex-direction: column; justify-content: space-between; background: var(--acid); }
-.release-notes h2 { max-width: 430px; margin: 0; font: 790 clamp(36px, 4vw, 58px)/.87 var(--display); letter-spacing: -.055em; }
-.release-notes article { display: flex; flex-direction: column; justify-content: flex-end; gap: 9px; }
-.release-notes article b { font: 760 25px/.95 var(--display); letter-spacing: -.035em; }
-.release-notes article span { color: var(--muted); font-size: 13px; line-height: 1.45; }
+.scroll-story { position: relative; min-height: 400vh; transition: background-color .7s ease; }
+.scroll-story[data-chapter='0'] { background: var(--yellow); }
+.scroll-story[data-chapter='1'] { background: var(--acid); }
+.scroll-story[data-chapter='2'] { background: var(--lilac); }
+.scroll-story[data-chapter='3'] { background: var(--blue); color: white; }
+.scroll-story__sticky { position: sticky; top: 0; display: grid; grid-template-columns: minmax(300px,.82fr) minmax(420px,1.18fr); gap: clamp(50px,8vw,130px); width: var(--page); height: 100svh; align-items: center; margin: 0 auto; overflow: hidden; padding: 100px 0 70px; }
+.story-copy { position: relative; min-height: 410px; }
+.story-copy > .overline { margin-bottom: 54px; }
+.story-copy__chapter { position: absolute; top: 94px; left: 0; width: 100%; opacity: 0; transform: translateY(36px); transition: opacity .42s ease, transform .52s var(--ease); pointer-events: none; }
+.story-copy__chapter.is-active { opacity: 1; transform: none; }
+.story-copy__chapter span { display: block; margin-bottom: 20px; font: 800 12px/1 var(--display); }
+.story-copy__chapter h3 { margin: 0; font: 850 clamp(54px,6.4vw,98px)/.79 var(--display); letter-spacing: -.072em; }
+.story-copy__chapter p { max-width: 490px; margin: 26px 0 0; font-size: clamp(16px,1.4vw,20px); line-height: 1.5; }
+.story-meter { position: absolute; bottom: 0; left: 0; display: flex; gap: 7px; }
+.story-meter i { width: 34px; height: 5px; border: 1px solid currentColor; border-radius: 999px; opacity: .4; transition: width .35s var(--ease), opacity .35s ease, background .35s ease; }
+.scroll-story[data-chapter='0'] .story-meter i:nth-child(1), .scroll-story[data-chapter='1'] .story-meter i:nth-child(2), .scroll-story[data-chapter='2'] .story-meter i:nth-child(3), .scroll-story[data-chapter='3'] .story-meter i:nth-child(4) { width: 60px; opacity: 1; background: currentColor; }
+.story-deck { position: relative; width: min(78%,560px); aspect-ratio: .82; justify-self: center; perspective: 1100px; }
+.story-card { --card-x: 0; --card-y: 0; --card-rotate: 0; --card-scale: 1; --card-opacity: 1; --card-z: 1; position: absolute; inset: 0; display: flex; flex-direction: column; justify-content: space-between; overflow: hidden; padding: clamp(28px,4vw,48px); border: 1px solid rgba(23,23,23,.3); border-radius: 7% 21% 6% 10%; box-shadow: 0 30px 70px rgba(23,23,23,.22); opacity: var(--card-opacity); transform: translate3d(calc(var(--card-x) * 1px),calc(var(--card-y) * 1px),0) rotate(calc(var(--card-rotate) * 1deg)) scale(var(--card-scale)); transition: opacity .12s linear; z-index: var(--card-z); isolation: isolate; }
+.story-card > span { font-size: 12px; font-weight: 850; letter-spacing: .11em; text-transform: uppercase; }
+.story-card > strong { font: 850 clamp(48px,5.5vw,84px)/.82 var(--display); letter-spacing: -.065em; }
+.story-card--day { background: var(--red); }
+.story-card__tape { position: absolute; z-index: -1; top: 29%; right: -8%; display: grid; width: 88%; grid-template-columns: 2fr 3fr 1.2fr 2fr; gap: 6px; transform: rotate(-8deg); }
+.story-card__tape i { height: 72px; background: var(--yellow); }
+.story-card__tape i:nth-child(2) { background: var(--pink); }
+.story-card__tape i:nth-child(3) { background: white; }
+.story-card__tape i:nth-child(4) { background: var(--blue); }
+.story-card--era { background: var(--acid); }
+.story-card__orbit { position: absolute; z-index: -1; top: 15%; right: -34%; width: 105%; aspect-ratio: 1; border: clamp(38px,6vw,90px) solid var(--blue); border-radius: 50%; }
+.story-card--pair { background: var(--lilac); }
+.story-card__pair { position: absolute; z-index: -1; top: 18%; right: 4%; display: flex; }
+.story-card__pair i { display: block; width: clamp(150px,18vw,245px); aspect-ratio: 1; border-radius: 50%; background: var(--red); mix-blend-mode: multiply; }
+.story-card__pair i + i { margin-left: -36%; background: var(--blue); }
+.story-card--year { background: var(--ink); color: white; }
+.story-card--year::before { position: absolute; z-index: -1; inset: 18% -25% auto auto; width: 100%; aspect-ratio: 1; border: clamp(34px,5vw,72px) solid var(--acid); border-radius: 50%; content: ''; }
+.story-card__burst { position: absolute; top: 9%; right: 10%; color: var(--red); font: 900 clamp(48px,6vw,90px)/1 var(--display); font-style: normal; }
 
-.principles { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; margin-top: 120px; margin-bottom: 120px; overflow: hidden; border-radius: 24px; background: var(--line); }
-.principles article { min-height: 210px; padding: 28px; background: var(--white); }
-.principles span { color: var(--muted); font-size: 11px; }
-.principles h3 { margin: 70px 0 8px; font: 760 clamp(28px, 2.8vw, 39px)/.95 var(--display); letter-spacing: -.04em; }
-.principles p { margin: 0; color: var(--muted); }
+.recap-gallery { padding: clamp(110px,14vw,200px) 0; }
+.gallery-heading { display: flex; align-items: end; justify-content: space-between; gap: 30px; margin-bottom: 42px; }
+.gallery-heading .overline { color: var(--muted); }
+.gallery-heading h2 { margin: 0; font: 850 clamp(54px,8vw,116px)/.78 var(--display); letter-spacing: -.073em; text-align: right; }
+.recap-shelf { display: grid; grid-template-columns: repeat(12,1fr); gap: 16px; }
+.recap-card { position: relative; display: flex; min-height: 310px; flex-direction: column; justify-content: space-between; overflow: hidden; padding: 25px; border: 1px solid rgba(23,23,23,.2); border-radius: 21px; transition: transform .3s var(--ease), box-shadow .3s ease; isolation: isolate; }
+.recap-card:hover { box-shadow: 0 20px 40px rgba(23,23,23,.14); transform: translateY(-8px) rotate(-1deg); }
+.recap-card span { font-size: 11px; font-weight: 850; letter-spacing: .09em; text-transform: uppercase; }
+.recap-card b { font: 820 clamp(28px,3vw,45px)/.85 var(--display); letter-spacing: -.055em; }
+.recap-card i { position: absolute; z-index: -1; right: -5%; bottom: -11%; opacity: .65; font: 900 clamp(120px,14vw,210px)/.8 var(--display); font-style: normal; }
+.recap-card--today { grid-column: span 3; background: var(--yellow); }
+.recap-card--week { grid-column: span 4; background: var(--red); }
+.recap-card--month { grid-column: span 5; background: var(--lilac); }
+.recap-card--year { grid-column: span 5; min-height: 390px; background: var(--blue); color: white; }
+.recap-card--timeline { grid-column: span 4; min-height: 390px; background: var(--ink); color: white; }
+.recap-card--on-this-day { grid-column: span 3; min-height: 390px; border-radius: 50% 50% 21px 21px; background: var(--pink); }
 
-.download-panel { display: grid; grid-template-columns: 1fr auto; gap: 42px; align-items: center; margin-bottom: 120px; padding: clamp(38px, 6vw, 84px); border-radius: 32px; background: var(--cobalt); color: white; }
-.download-panel .overline { color: rgba(255,255,255,.7); }
-.download-panel h2 { margin: 0; font: 820 clamp(48px, 6vw, 86px)/.85 var(--display); letter-spacing: -.06em; }
-.download-button--light { background: white; color: var(--ink); }
-.download-button--light:hover { background: var(--acid); color: var(--ink); }
-.download-platforms { grid-column: 1 / -1; display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1px; overflow: hidden; border-radius: 17px; background: rgba(255,255,255,.26); }
-.download-platforms a { display: grid; gap: 5px; min-width: 0; padding: 14px 16px; background: rgba(21,21,21,.13); transition: background .2s ease; }
-.download-platforms a:hover { background: rgba(21,21,21,.28); }
-.download-platforms b { font-size: 14px; }
-.download-platforms span { color: rgba(255,255,255,.75); font-size: 11px; }
-.checksum { grid-column: 1 / -1; display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: 12px; align-items: center; padding-top: 26px; border-top: 1px solid rgba(255,255,255,.28); }
-.checksum > span:not(.sr-only) { font-size: 11px; font-weight: 700; letter-spacing: .08em; }
-.checksum strong { overflow: hidden; opacity: .78; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
-.checksum i { font-size: 19px; font-style: normal; transition: transform .2s ease; }
+.not-timesheet { display: grid; grid-template-columns: 1.2fr .8fr; gap: clamp(54px,10vw,160px); align-items: end; padding: clamp(70px,10vw,140px); border-radius: 32px; background: var(--acid); }
+.not-timesheet h2 { margin: 24px 0 0; font: 850 clamp(52px,7vw,102px)/.8 var(--display); letter-spacing: -.07em; }
+.not-timesheet h2 em { color: var(--blue); font-weight: 430; }
+.not-timesheet__copy p { margin: 0 0 25px; font-size: clamp(17px,1.55vw,21px); line-height: 1.52; }
+
+.product-window { margin-top: clamp(100px,13vw,180px); overflow: hidden; border: 1px solid var(--ink); border-radius: 24px; background: var(--ink); box-shadow: 0 25px 70px rgba(23,23,23,.16); }
+.product-window__bar { display: flex; height: 48px; align-items: center; gap: 7px; padding: 0 15px; color: white; }
+.product-window__bar i { width: 10px; height: 10px; border-radius: 50%; background: var(--red); }
+.product-window__bar i:nth-child(2) { background: var(--yellow); }
+.product-window__bar i:nth-child(3) { background: var(--acid); }
+.product-window__bar span { margin-left: auto; opacity: .65; font-size: 10px; font-weight: 800; letter-spacing: .11em; }
+.product-window figure { position: relative; margin: 0; }
+.product-window img { width: 100%; height: auto; border-top: 1px solid var(--ink); }
+.product-window figcaption { position: absolute; right: 3%; bottom: 5%; width: min(430px,42%); padding: 28px; border: 1px solid var(--ink); border-radius: 18px 32px 17px 20px; background: var(--paper); transform: rotate(-2deg); }
+.product-window figcaption h2 { margin: 18px 0 12px; font: 820 clamp(34px,4vw,58px)/.84 var(--display); letter-spacing: -.06em; }
+.product-window figcaption p:last-child { margin: 0; color: var(--muted); line-height: 1.45; }
+
+.release-board { display: grid; grid-template-columns: .84fr 1.16fr; gap: clamp(46px,8vw,130px); align-items: start; padding: clamp(110px,15vw,210px) 0; }
+.release-board__title { position: sticky; top: 140px; }
+.release-board__title .overline { color: var(--red); }
+.release-board__title h2 { margin: 25px 0; font: 850 clamp(48px,6vw,88px)/.8 var(--display); letter-spacing: -.068em; }
+.release-board__title > span { color: var(--muted); font-size: 13px; font-weight: 700; }
+.release-board__notes { border-top: 1px solid var(--ink); }
+.release-board__notes article { display: grid; grid-template-columns: 60px 1fr; gap: 18px; min-height: 170px; align-items: start; padding: 27px 0; border-bottom: 1px solid var(--ink); }
+.release-board__notes article > span { font: 760 12px/1 var(--display); }
+.release-board__notes article b { font: 810 clamp(29px,3vw,44px)/.9 var(--display); letter-spacing: -.045em; }
+.release-board__notes article p { max-width: 530px; margin: 14px 0 0; color: var(--muted); font-size: 16px; line-height: 1.5; }
+
+.principles { display: grid; grid-template-columns: repeat(3,1fr); gap: 1px; overflow: hidden; border: 1px solid var(--ink); border-radius: 28px; background: var(--ink); }
+.principles article { min-height: 330px; padding: 28px; background: var(--yellow); }
+.principles article:nth-child(2) { background: var(--lilac); }
+.principles article:nth-child(3) { background: var(--red); }
+.principles span { font-size: 11px; font-weight: 850; letter-spacing: .12em; }
+.principles h3 { margin: 120px 0 12px; font: 830 clamp(31px,3.2vw,48px)/.87 var(--display); letter-spacing: -.052em; }
+.principles p { max-width: 360px; margin: 0; line-height: 1.5; }
+
+.download-panel { margin-top: clamp(110px,15vw,210px); margin-bottom: 90px; padding: clamp(42px,7vw,100px); border-radius: 34px; background: var(--blue); color: white; }
+.download-panel__intro { display: flex; align-items: end; justify-content: space-between; gap: 30px; margin-bottom: 55px; }
+.download-panel .overline { color: var(--acid); }
+.download-panel h2 { margin: 20px 0 0; font: 850 clamp(58px,8vw,118px)/.78 var(--display); letter-spacing: -.072em; }
+.download-grid { display: grid; grid-template-columns: repeat(5,1fr); overflow: hidden; border: 1px solid rgba(255,255,255,.48); border-radius: 20px; }
+.download-grid a { position: relative; display: grid; min-height: 150px; align-content: end; gap: 6px; padding: 18px; border-right: 1px solid rgba(255,255,255,.48); transition: background .24s ease, color .24s ease; }
+.download-grid a:last-child { border-right: 0; }
+.download-grid a:hover { background: var(--acid); color: var(--ink); }
+.download-grid span { opacity: .72; font-size: 11px; }
+.download-grid b { font-size: 15px; }
+.download-grid i { position: absolute; top: 15px; right: 16px; font-size: 22px; font-style: normal; transition: transform .22s var(--ease); }
+.download-grid a:hover i { transform: translateY(5px); }
+.download-footnote { display: flex; align-items: center; justify-content: space-between; gap: 30px; margin-top: 20px; color: rgba(255,255,255,.72); font-size: 11px; }
+.checksum { display: inline-flex; align-items: center; gap: 8px; color: white; font-weight: 750; }
+.checksum i { font-style: normal; transition: transform .2s var(--ease); }
 .checksum:hover i { transform: translateX(4px); }
 
-footer { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 30px; padding: 0 0 42px; color: var(--muted); font-size: 13px; }
-.brand--small { color: var(--ink); font-weight: 700; }
-.brand--small .brand__stamp { width: 32px; height: 32px; border-radius: 9px; font-size: 10px; }
+footer { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 30px; padding-bottom: 44px; color: var(--muted); font-size: 12px; }
+.brand--small { color: var(--ink); font-weight: 750; }
+.brand--small .brand__stamp { width: 32px; height: 32px; border-radius: 7px 12px 8px 9px; font-size: 10px; }
 footer nav { display: flex; gap: 24px; }
 footer nav a:hover { color: var(--ink); }
 footer > span { text-align: right; }
 
-.js .reveal { opacity: 0; transform: translateY(22px); transition: opacity .65s ease, transform .65s cubic-bezier(.2,.8,.2,1); }
-.js .reveal.is-visible { opacity: 1; transform: translateY(0); }
+.js [data-reveal] { opacity: 0; transform: translateY(56px) scale(.985); transition: opacity .65s ease, transform .75s var(--ease); }
+.js [data-reveal].is-visible { opacity: 1; transform: none; }
+.js .recap-card[data-reveal]:nth-child(2), .js .release-board__notes article[data-reveal]:nth-child(2) { transition-delay: .06s; }
+.js .recap-card[data-reveal]:nth-child(3), .js .release-board__notes article[data-reveal]:nth-child(3) { transition-delay: .12s; }
+.js .recap-card[data-reveal]:nth-child(4), .js .release-board__notes article[data-reveal]:nth-child(4) { transition-delay: .18s; }
 
-@media (max-width: 1000px) {
-  .hero { grid-template-columns: 1fr; padding-top: 70px; }
-  .hero__copy { max-width: 760px; }
-  .today-cover { min-height: 570px; }
-  .recap-shelf { grid-template-columns: repeat(5, 240px); }
-  .story__scenes { grid-template-columns: 1fr; }
-  .release-notes { grid-template-columns: repeat(2, 1fr); }
-  .scene { min-height: 220px; }
+@media (max-width: 1100px) {
+  :root { --page: min(100% - 44px, 1480px); }
+  .hero { grid-template-columns: 1fr; padding-top: 150px; }
+  .hero__copy { max-width: 800px; }
+  .mixtape-stage { width: min(100%,820px); min-height: 690px; margin: 0 auto; }
+  .scroll-cue { display: none; }
+  .scroll-story__sticky { grid-template-columns: 1fr 1fr; gap: 40px; }
+  .recap-card--today, .recap-card--week, .recap-card--month, .recap-card--year, .recap-card--timeline, .recap-card--on-this-day { grid-column: span 4; }
+  .download-grid { grid-template-columns: repeat(3,1fr); }
+  .download-grid a:nth-child(3) { border-right: 0; }
+  .download-grid a:nth-child(n + 4) { border-top: 1px solid rgba(255,255,255,.48); }
 }
 
-@media (max-width: 700px) {
-  .site-header, .hero, .recap-section, .story, .release-notes, .principles, .download-panel, footer { width: min(100% - 32px, 1500px); }
-  .site-header { height: 74px; }
-  .brand__name { display: none; }
-  .hero { min-height: auto; gap: 56px; padding: 58px 0 82px; }
-  .hero h1 { font-size: clamp(58px, 19vw, 90px); }
-  .hero__actions { align-items: flex-start; flex-direction: column; }
-  .today-cover { min-height: 440px; border-radius: 28px; }
-  .today-cover__copy { right: 28px; bottom: 30px; left: 28px; width: auto; }
-  .today-cover__copy strong { max-width: 70%; }
-  .today-cover__activity { right: -8%; bottom: 22%; width: 74%; }
-  .recap-section { padding: 64px 0 88px; }
-  .section-heading { align-items: start; flex-direction: column; }
-  .recap-shelf { margin-right: -16px; grid-template-columns: repeat(5, 215px); }
-  .story { padding: 44px 24px; border-radius: 28px; }
-  .story__copy { margin-bottom: 44px; }
-  .story h2 { font-size: clamp(52px, 16vw, 78px); }
-  .principles { grid-template-columns: 1fr; margin-top: 88px; margin-bottom: 88px; }
-  .principles article { min-height: 160px; }
-  .principles h3 { margin-top: 42px; }
-  .download-panel { grid-template-columns: 1fr; margin-bottom: 82px; padding: 40px 26px; }
-  .download-panel .download-button { justify-self: start; }
-  .download-platforms { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .checksum { grid-template-columns: 1fr auto; }
-  .checksum > span:not(.sr-only) { grid-column: 1 / -1; }
+@media (max-width: 760px) {
+  :root { --page: min(100% - 28px, 1480px); }
+  .site-header { top: 10px; grid-template-columns: 1fr auto; min-height: 58px; }
+  .site-nav, .brand__name { display: none; }
+  .brand__stamp { width: 36px; height: 36px; }
+  .header-download { padding: 11px 16px; }
+  .hero { min-height: auto; gap: 36px; padding: 120px 0 80px; }
+  .hero h1 { font-size: clamp(60px,19vw,94px); }
+  .hero__lede { margin-top: 26px; }
+  .hero__actions { align-items: flex-start; flex-direction: column; gap: 14px; }
+  .mixtape-stage { min-height: 490px; }
+  .hero-cover { width: min(70%,330px); padding: 22px; }
+  .hero-cover strong { font-size: clamp(32px,9vw,48px); }
+  .hero-cover--today { transform: translate(-72%,-43%) rotate(-9deg); }
+  .hero-cover--week { transform: translate(-48%,-50%) rotate(4deg); }
+  .hero-cover--year { transform: translate(-23%,-46%) rotate(12deg); }
+  .hero-cover--memory { transform: translate(-1%,-40%) rotate(18deg); }
+  .mixtape-stage__stamp { top: 5%; right: 0; width: 68px; height: 68px; font-size: 15px; }
+  .memory-intro { padding: 100px 0 88px; }
+  .memory-intro h2 { font-size: clamp(48px,15vw,78px); }
+  .scroll-story { min-height: 400vh; }
+  .scroll-story__sticky { grid-template-columns: 1fr; grid-template-rows: .8fr 1.2fr; gap: 18px; height: 100svh; padding: 88px 0 18px; }
+  .story-copy { min-height: 240px; }
+  .story-copy > .overline { margin-bottom: 22px; }
+  .story-copy__chapter { top: 45px; }
+  .story-copy__chapter span { margin-bottom: 10px; }
+  .story-copy__chapter h3 { font-size: clamp(42px,13vw,66px); }
+  .story-copy__chapter p { max-width: 96%; margin-top: 12px; font-size: 14px; }
+  .story-meter { display: none; }
+  .story-deck { width: min(62vw,300px); align-self: center; }
+  .story-card { padding: 23px; }
+  .story-card > strong { font-size: clamp(38px,11vw,54px); }
+  .gallery-heading { align-items: start; flex-direction: column; }
+  .gallery-heading h2 { text-align: left; }
+  .recap-shelf { grid-template-columns: 1fr 1fr; }
+  .recap-card, .recap-card--today, .recap-card--week, .recap-card--month, .recap-card--year, .recap-card--timeline, .recap-card--on-this-day { grid-column: span 1; min-height: 260px; }
+  .not-timesheet { grid-template-columns: 1fr; gap: 38px; padding: 52px 26px; }
+  .not-timesheet h2 { font-size: clamp(48px,14vw,74px); }
+  .product-window { border-radius: 16px; }
+  .product-window__bar { height: 40px; }
+  .product-window figcaption { position: relative; right: auto; bottom: auto; width: 100%; border: 0; border-radius: 0; transform: none; }
+  .release-board { grid-template-columns: 1fr; padding: 110px 0; }
+  .release-board__title { position: static; }
+  .principles { grid-template-columns: 1fr; }
+  .principles article { min-height: 240px; }
+  .principles h3 { margin-top: 70px; }
+  .download-panel { margin-top: 110px; margin-bottom: 70px; padding: 45px 22px; }
+  .download-panel__intro { align-items: start; flex-direction: column; }
+  .download-grid { grid-template-columns: 1fr 1fr; }
+  .download-grid a, .download-grid a:nth-child(3) { border-right: 1px solid rgba(255,255,255,.48); }
+  .download-grid a:nth-child(even) { border-right: 0; }
+  .download-grid a:nth-child(n + 3) { border-top: 1px solid rgba(255,255,255,.48); }
+  .download-grid a:last-child { grid-column: 1 / -1; border-right: 0; }
+  .download-footnote { align-items: flex-start; flex-direction: column; }
   footer { grid-template-columns: 1fr auto; }
-  footer nav { grid-column: 1 / -1; grid-row: 1; }
+  footer nav { grid-column: 1 / -1; grid-row: 1; flex-wrap: wrap; }
   footer .brand { grid-row: 2; }
   footer > span { grid-row: 2; }
 }
 
-@media (max-width: 520px) {
-  .release-notes { grid-template-columns: 1fr; }
-  .download-platforms { grid-template-columns: 1fr; }
+@media (max-width: 460px) {
+  .recap-shelf { grid-template-columns: 1fr; }
+  .recap-card, .recap-card--today, .recap-card--week, .recap-card--month, .recap-card--year, .recap-card--timeline, .recap-card--on-this-day { grid-column: 1; }
+  .download-grid { grid-template-columns: 1fr; }
+  .download-grid a, .download-grid a:nth-child(even), .download-grid a:nth-child(3) { grid-column: auto; border-top: 1px solid rgba(255,255,255,.48); border-right: 0; }
+  .download-grid a:first-child { border-top: 0; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
-  *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
-  .js .reveal { opacity: 1; transform: none; }
+  *, *::before, *::after { animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
+  .recap-ticker > div { animation: none; }
+  .js [data-reveal] { opacity: 1; transform: none; }
+  .scroll-story { min-height: auto; padding: 80px 0; background: var(--yellow) !important; color: var(--ink) !important; }
+  .scroll-story__sticky { position: static; grid-template-columns: 1fr; height: auto; overflow: visible; padding: 0; }
+  .story-copy { min-height: auto; }
+  .story-copy__chapter { position: static; margin-top: 50px; opacity: 1; transform: none; }
+  .story-meter { display: none; }
+  .story-deck { display: grid; width: 100%; grid-template-columns: repeat(2,1fr); gap: 16px; aspect-ratio: auto; }
+  .story-card { position: relative; inset: auto; min-height: 430px; opacity: 1 !important; transform: none !important; }
+}
+
+@media (prefers-reduced-motion: reduce) and (max-width: 760px) {
+  .story-deck { grid-template-columns: 1fr; }
+  .story-card { min-height: 390px; }
 }


### PR DESCRIPTION
## What changed

- fixes cross-platform packaging so CI never implicitly publishes and the tag workflow verifies all five installers
- rebuilds the website as a bright, scroll-driven visual recap with reduced-motion support
- adds stronger SoftwareApplication, image, sitemap, and social metadata
- rewrites the README and adds cross-platform install, support, changelog, and generated-release guidance

## Verified

- 189 app tests
- TypeScript and production build
- 9 release, promotion, and website motion regression tests
- Windows activity smoke
- six-resolution visual smoke
- website validation and Netlify package generation

The v1.2.0 tag should be created only after this PR is merged and main is green.